### PR TITLE
Add host config mode with Zod-backed schemas and safer defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Prepare MCP config
+        run: |
+          if [ ! -f mcp-config.json ]; then
+            cp mcp-config.example.json mcp-config.json
+          fi
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ ENV/
 logging/*.log
 assets/
 downloads/
+mcp-config.json

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -4,6 +4,35 @@ This file serves as a personal diary for ideas, issues and progress with the dev
 
 ---
 
+## 11. 03. 2026
+
+TODO: have to make a way to tell agent about required items per server
+I'm thinking about { required: { dirs: string[] }}
+But what about dynamically added servers, and avoiding hardcoding config.
+LLM could in theory react to MCP server error about missing config.
+
+- But that exposes vulnerability, right?
+- But what if I limit config changes to only that server.
+- I can always ask the user if they want to modify config based on LLM idea.
+
+An app that configures itself during runtime:
+
+- Requires instructions update to format message in special way
+- "idea": { message: string, validationSchema: string, serverName: string }
+  LLM could:
+- Provide idea what to set based on error message ("Server X failed because of Y")
+- Propose to set and validate Y for server X
+- If allowed it would update config for server X
+- BUT IT would have to know to read and send with server config "does it work out of the box?"
+
+## 10. 03. 2026
+
+Thinking of keeping track of allowed directories
+
+- If user provides them at runtime, they should be respected
+- Else if user adds them to mcp-config.json, they should be read
+- Else tell the user to configure dirs - exit, maybe?
+
 ### 19. 07. 2025
 
 ## Prompt Engineering

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Set `agentProvider` to `remoteAgent` or `localAgent` depending on which provider
 - [x] Add unit high and medium value tests
 - [-] Simplify config and Zod schemas
 - [ ] Enter chat mode when no args are provided, remove isChatEnabled flag
+- [ ] Implement terminal history
 - [ ] Re-iterate on user flow and plan it with stories, then implement changes
 - [ ] Train and use a smaller domain specific model
 

--- a/README.md
+++ b/README.md
@@ -89,14 +89,17 @@ Set `agentProvider` to `remoteAgent` or `localAgent` depending on which provider
 - [x] Move allowed dirs from mcp-config to host app args
 - [ ] Enable tool toogle or multiple select for allowed/banned
 - [ ] Provide script argument for local/remote model
-- [-] Implement in-app model selection
-- [-] Implement in-app provider selection
-- [-] Implement in-app allowed directories selection
+- [x] Implement in-app model selection
+- [x] Implement in-app provider selection
+- [x] Implement in-app allowed directories selection
+- [ ] Use MCP to handle roots change instead of restarting agent on dirs change
 - [x] Add unit high and medium value tests
-- [-] Simplify config and Zod schemas
+- [x] Simplify config and Zod schemas
 - [ ] Enter chat mode when no args are provided, remove isChatEnabled flag
 - [ ] Implement terminal history
-- [ ] Re-iterate on user flow and plan it with stories, then implement changes
+- [ ] Create a user flow, ask what would a user want, and refactor where valuable
+- [ ] Treat local agent as Ollama Custom Provider
+- [ ] Simplify agents by merging Local and Remote Agent
 - [ ] Train and use a smaller domain specific model
 
 ## License

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Set `agentProvider` to `remoteAgent` or `localAgent` depending on which provider
 - [ ] Implement in-app model selection
 - [ ] Implement in-app provider selection
 - [x] Add unit high and medium value tests
+- [ ] Simplify config and Zod schemas
+- [ ] Enter chat mode when no args are provided, remove isChatEnabled flag
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -84,17 +84,19 @@ Set `agentProvider` to `remoteAgent` or `localAgent` depending on which provider
 - [ ] Merge ollama and uplink docker stages into a single stage
 - [x] Update UX with external CLI libraries (@clack/prompt and @chalk)
 - [x] Use input arguments for run startup commands
-- [ ] Train and use a smaller domain specific model
 - [x] Add .env.example to simplify setting environment variables
 - [x] Fix new setup where ENOENT: no such file or directory, open 'logging/local.log'
 - [x] Move allowed dirs from mcp-config to host app args
-- [ ] Enable tool toogle
+- [ ] Enable tool toogle or multiple select for allowed/banned
 - [ ] Provide script argument for local/remote model
-- [ ] Implement in-app model selection
-- [ ] Implement in-app provider selection
+- [-] Implement in-app model selection
+- [-] Implement in-app provider selection
+- [-] Implement in-app allowed directories selection
 - [x] Add unit high and medium value tests
-- [ ] Simplify config and Zod schemas
+- [-] Simplify config and Zod schemas
 - [ ] Enter chat mode when no args are provided, remove isChatEnabled flag
+- [ ] Re-iterate on user flow and plan it with stories, then implement changes
+- [ ] Train and use a smaller domain specific model
 
 ## License
 

--- a/agents/local-agent.ts
+++ b/agents/local-agent.ts
@@ -3,12 +3,12 @@ import { connectToMCPServers } from "../lib/connect-to-mcp-servers";
 import { log, spinner } from '@clack/prompts';
 import chalk from 'chalk';
 
-import { type Config } from "../lib/get-mcp-config";
 import { logLocalResponse } from "../lib/message-logger";
 import { LocalModel } from "../models/llm";
 import type { Message, Tool, ToolCall, ChatResponse } from "ollama";
 import type { AllowedDirs } from "../lib/get-dirs-from-args";
-import type { McpConfig } from "../config";
+import type { McpConfig } from "../config-validation";
+import { getConfig } from "../lib/get-mcp-config";
 
 export interface SolveResult {
   content: string | null;
@@ -18,17 +18,15 @@ export interface SolveResult {
 type CallToolResponse = Awaited<ReturnType<Client["callTool"]>>;
 
 export class LocalAgent {
-  private model: LocalModel;
+  private model: LocalModel | null = null;
   private clients: Map<string, Client>;
   private toolMap: Map<string, Client>;
   public tools: Tool[] = [];
   private messages: Message[];
-  private config: McpConfig;
   private allowedDirs: AllowedDirs;
 
   constructor({
     instructions,
-    config,
     allowedDirs
   }: {
     instructions: string;
@@ -44,14 +42,17 @@ export class LocalAgent {
     ];
     this.toolMap = new Map();
     this.clients = new Map();
-    this.config = config;
-    this.model = new LocalModel({
-      modelId: config.localAgent.modelId,
-      host: config.localAgent.host,
-    });
   }
 
-  async connect(config: McpConfig) {
+  async connect() {
+    const config = await getConfig();
+    if (!this.model) {
+      this.model = new LocalModel({
+        modelId: config.localAgent.modelId,
+        host: config.localAgent.host,
+        models: config.localAgent.models
+      });
+    }
     const startTime = performance.now();
     const { clients, toolMap, tools } = await connectToMCPServers(config, this.allowedDirs);
     this.clients = clients;
@@ -69,17 +70,18 @@ export class LocalAgent {
 
   async warmUpModel(): Promise<void> {
     const warmupSpinner = spinner();
+    const config = await getConfig();
 
     warmupSpinner.start(
-      `Warming up model ${this.config.localAgent.modelId} with ${this.tools.length} tools...`
+      `Warming up model ${config.localAgent.modelId} with ${this.tools.length} tools...`
     );
 
     try {
-      const response = await fetch(`${this.config.localAgent.host}/api/chat`, {
+      const response = await fetch(`${config.localAgent.host}/api/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          model: this.config.localAgent.modelId,
+          model: config.localAgent.modelId,
           messages: [{ role: "user", content: "Hi" }],
           tools: this.tools,
           stream: false,
@@ -91,17 +93,18 @@ export class LocalAgent {
       }
 
       await response.json();
-      warmupSpinner.stop(`Local model ${this.config.localAgent.modelId} ready.`);
+      warmupSpinner.stop(`Local model ${config.localAgent.modelId} ready.`);
     } catch (error) {
       throw new Error(
-        `Failed to warm up model. Ensure Ollama is running at ${this.config.localAgent.host
-        } with model ${this.config.localAgent.modelId}\nError: ${error instanceof Error ? error.message : "Unknown error"
+        `Failed to warm up model. Ensure Ollama is running at ${config.localAgent.host
+        } with model ${config.localAgent.modelId}\nError: ${error instanceof Error ? error.message : "Unknown error"
         }`
       );
     }
   }
 
   async solve(prompt: string, maxIterations = 100): Promise<SolveResult> {
+    const config = await getConfig();
     const solveStart = performance.now();
     let chatResponse: ChatResponse | undefined;
     let toolCalls: ToolCall[];
@@ -132,7 +135,7 @@ export class LocalAgent {
         break;
       }
       // first process the prompt
-      chatResponse = await this.model.createMessage({
+      chatResponse = await this.model!.createMessage({
         messages: this.messages,
         tools: this.tools,
       });
@@ -242,7 +245,7 @@ export class LocalAgent {
     );
     logLocalResponse({
       solve: {
-        modelId: this.config.localAgent.modelId,
+        modelId: config.localAgent.modelId,
         totalDuration: solveTotalTime,
         toolCallsCount,
         toolCallsTotalTime,
@@ -266,6 +269,12 @@ export class LocalAgent {
         .join("\n");
     }
     return String(content);
+  }
+
+  async setModel(modelId: string) {
+    await this.cleanup();
+    await this.model?.setModel(modelId);
+    await this.connect();
   }
 
   async cleanup() {

--- a/agents/local-agent.ts
+++ b/agents/local-agent.ts
@@ -1,14 +1,14 @@
 import { Client } from "../client/client";
-import { connectToMCPServers } from "../lib/connect-to-mcp-servers";
 import { log, spinner } from '@clack/prompts';
 import chalk from 'chalk';
 
 import { logLocalResponse } from "../lib/message-logger";
 import { LocalModel } from "../models/llm";
 import type { Message, Tool, ToolCall, ChatResponse } from "ollama";
-import type { AllowedDirs } from "../lib/get-dirs-from-args";
 import type { McpConfig } from "../config-validation";
-import { getConfig } from "../lib/get-mcp-config";
+import type { AllowedDirs } from "../lib/get-dirs-from-args";
+import { connectToMCPServers } from "../lib/connect-to-mcp-servers";
+import { coolDownModel, warmUpModel } from "../lib/ollama-models";
 
 export interface SolveResult {
   content: string | null;
@@ -19,92 +19,83 @@ type CallToolResponse = Awaited<ReturnType<Client["callTool"]>>;
 
 export class LocalAgent {
   private model: LocalModel | null = null;
-  private clients: Map<string, Client>;
-  private toolMap: Map<string, Client>;
   public tools: Tool[] = [];
+  private toolMap: Map<string, Client>;
   private messages: Message[];
-  private allowedDirs: AllowedDirs;
+  private config: McpConfig["providers"][string];
+
+  static async connectMCPServers(allowedDirs: AllowedDirs) {
+    return await connectToMCPServers(allowedDirs);
+  }
 
   constructor({
     instructions,
-    allowedDirs
+    tools,
+    toolMap,
+    config
   }: {
     instructions: string;
-    config: McpConfig;
-    allowedDirs: AllowedDirs
+    tools: Tool[];
+    toolMap: Map<string, Client>;
+    config: McpConfig["providers"][string];
   }) {
-    this.allowedDirs = allowedDirs;
+    this.tools = tools;
+    this.toolMap = toolMap;
+    this.config = config;
     this.messages = [
       {
         role: "system",
         content: instructions,
       },
     ];
-    this.toolMap = new Map();
-    this.clients = new Map();
   }
 
-  async connect() {
-    const config = await getConfig();
-    if (!this.model) {
-      this.model = new LocalModel({
-        modelId: config.localAgent.modelId,
-        host: config.localAgent.host,
-        models: config.localAgent.models
-      });
-    }
-    const startTime = performance.now();
-    const { clients, toolMap, tools } = await connectToMCPServers(config, this.allowedDirs);
-    this.clients = clients;
-    this.toolMap = toolMap;
-    this.tools = tools;
-    await this.warmUpModel();
-    const connectTime = +((performance.now() - startTime) / 1000).toFixed(2);
-    logLocalResponse({
-      init: {
-        modelId: config.localAgent.modelId,
-        totalDuration: connectTime,
-      },
-    });
-  }
-
-  async warmUpModel(): Promise<void> {
+  async start() {
     const warmupSpinner = spinner();
-    const config = await getConfig();
-
     warmupSpinner.start(
-      `Warming up model ${config.localAgent.modelId} with ${this.tools.length} tools...`
+      `Warming up local model ${this.config.modelId} with ${this.tools.length} tools...`
     );
 
     try {
-      const response = await fetch(`${config.localAgent.host}/api/chat`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          model: config.localAgent.modelId,
-          messages: [{ role: "user", content: "Hi" }],
-          tools: this.tools,
-          stream: false,
-        }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+      if (!this.model) {
+        this.model = new LocalModel({
+          modelId: this.config.modelId,
+          host: this.config.host,
+          models: this.config.models
+        });
       }
-
-      await response.json();
-      warmupSpinner.stop(`Local model ${config.localAgent.modelId} ready.`);
-    } catch (error) {
-      throw new Error(
-        `Failed to warm up model. Ensure Ollama is running at ${config.localAgent.host
-        } with model ${config.localAgent.modelId}\nError: ${error instanceof Error ? error.message : "Unknown error"
-        }`
-      );
+      const startTime = performance.now();
+      await warmUpModel(this.config.host, this.config.modelId, this.tools);
+      const connectTime = +((performance.now() - startTime) / 1000).toFixed(2);
+      logLocalResponse({
+        init: {
+          modelId: this.config.modelId,
+          totalDuration: connectTime,
+        },
+      });
+      warmupSpinner.stop(`Local model ${this.config.modelId} ready.`);
+    } catch (_) {
+      const errorMessage = `Failed to initialize local agent with ${this.config.modelId}`;
+      warmupSpinner.stop("");
+      log.error(errorMessage);
+      throw new Error(errorMessage);
     }
   }
 
+  async stop() {
+    const stoppingSpinner = spinner();
+    stoppingSpinner.start(`Stopping local model ${this.config.modelId}`);
+    // Abort work
+    this.model?.cancel();
+    // Unload model
+    await coolDownModel(this.config.host, this.config.modelId);
+    // Garbage collection
+    this.model = null;
+    this.messages = [];
+    stoppingSpinner.stop(`Local model ${this.config.modelId} stopped`);
+  }
+
   async solve(prompt: string, maxIterations = 100): Promise<SolveResult> {
-    const config = await getConfig();
     const solveStart = performance.now();
     let chatResponse: ChatResponse | undefined;
     let toolCalls: ToolCall[];
@@ -123,141 +114,146 @@ export class LocalAgent {
     let iterations = 0;
 
     const thinkingSpinner = spinner();
-    thinkingSpinner.start(chalk.dim("Assistant thinking..."));
+    thinkingSpinner.start(chalk.dim("Assistant thinking"));
 
-    do {
-      if (iterations++ >= maxIterations) {
-        this.messages.push({
-          role: "assistant",
-          content:
-            "I've reached the maximum number of iterations. Here's what I've accomplished so far...",
+    try {
+      do {
+        if (iterations++ >= maxIterations) {
+          this.messages.push({
+            role: "assistant",
+            content:
+              "I've reached the maximum number of iterations. Here's what I've accomplished so far...",
+          });
+          break;
+        }
+        // first process the prompt
+        chatResponse = await this.model!.createMessage({
+          messages: this.messages,
+          tools: this.tools,
         });
-        break;
-      }
-      // first process the prompt
-      chatResponse = await this.model!.createMessage({
-        messages: this.messages,
-        tools: this.tools,
-      });
 
-      iterationsCount++;
+        iterationsCount++;
 
-      if (!chatResponse.message.content && chatResponse.message.thinking) {
-        thinkingSpinner.message(`Assistant thinking... ${chalk.dim(chatResponse.message.thinking)}`);
-      }
+        if (!chatResponse.message.content && chatResponse.message.thinking) {
+          thinkingSpinner.message(`Assistant thinking... ${chalk.dim(chatResponse.message.thinking)}`);
+        }
 
-      this.messages.push(chatResponse.message);
-      toolCalls = chatResponse.message.tool_calls ?? [];
+        this.messages.push(chatResponse.message);
+        toolCalls = chatResponse.message.tool_calls ?? [];
 
-      // decide on action
-      if (toolCalls.length > 0) {
-        const toolCallsStartTime = performance.now();
-        // agent decides if it should make tool calls
-        for (const {
-          function: { name: toolName, arguments: toolArgs },
-        } of toolCalls) {
-          const client = this.toolMap.get(toolName)!;
-          try {
-            const toolResponse = await client.callToolWithTimeout(
-              toolName,
-              toolArgs
-            );
-            toolCallsCount++;
+        // decide on action
+        if (toolCalls.length > 0) {
+          const toolCallsStartTime = performance.now();
+          // agent decides if it should make tool calls
+          for (const {
+            function: { name: toolName, arguments: toolArgs },
+          } of toolCalls) {
+            const client = this.toolMap.get(toolName)!;
+            try {
+              const toolResponse = await client.callToolWithTimeout(
+                toolName,
+                toolArgs
+              );
+              toolCallsCount++;
 
-            if (!toolResponse) {
-              // Handle timeout or tool error - track attempts
+              if (!toolResponse) {
+                // Handle timeout or tool error - track attempts
+                const attempts = (toolAttempts.get(toolName) || 0) + 1;
+                toolAttempts.set(toolName, attempts);
+
+                if (attempts >= maxToolRetries) {
+                  // Max retries reached - fail the entire solve
+                  break;
+                }
+
+                // Add error message and let agent retry
+                const errorMessage = `Tool "${toolName}" failed: The tool either timed out or encountered an error. Please try again.`;
+                this.messages.push({
+                  role: "tool",
+                  content: errorMessage,
+                });
+                break; // Stop processing remaining tools, let agent retry
+              }
+
+              const formattedResponse = this.formatToolResponse(toolResponse);
+              this.messages.push({
+                role: "tool",
+                content: formattedResponse,
+              });
+              // Reset attempt counter on success
+              toolAttempts.delete(toolName);
+            } catch (error) {
+              // Handle tool execution error - track attempts
               const attempts = (toolAttempts.get(toolName) || 0) + 1;
               toolAttempts.set(toolName, attempts);
+              const errorMessage = `Error executing "${toolName}": ${error instanceof Error ? error.message : "Unknown error"
+                }`;
+              log.error(
+                `Tool [error]: ${errorMessage} (attempt ${attempts}/${maxToolRetries})`
+              );
 
               if (attempts >= maxToolRetries) {
                 // Max retries reached - fail the entire solve
-                break;
+                return {
+                  content: null,
+                  error: `Tool "${toolName}" failed after ${maxToolRetries} attempts: ${errorMessage}`,
+                };
               }
 
               // Add error message and let agent retry
-              const errorMessage = `Tool "${toolName}" failed: The tool either timed out or encountered an error. Please try again.`;
               this.messages.push({
                 role: "tool",
-                content: errorMessage,
+                content: errorMessage + " Please try again.",
               });
               break; // Stop processing remaining tools, let agent retry
             }
-
-            const formattedResponse = this.formatToolResponse(toolResponse);
-            this.messages.push({
-              role: "tool",
-              content: formattedResponse,
-            });
-            // Reset attempt counter on success
-            toolAttempts.delete(toolName);
-          } catch (error) {
-            // Handle tool execution error - track attempts
-            const attempts = (toolAttempts.get(toolName) || 0) + 1;
-            toolAttempts.set(toolName, attempts);
-            const errorMessage = `Error executing "${toolName}": ${error instanceof Error ? error.message : "Unknown error"
-              }`;
-            log.error(
-              `Tool [error]: ${errorMessage} (attempt ${attempts}/${maxToolRetries})`
-            );
-
-            if (attempts >= maxToolRetries) {
-              // Max retries reached - fail the entire solve
-              return {
-                content: null,
-                error: `Tool "${toolName}" failed after ${maxToolRetries} attempts: ${errorMessage}`,
-              };
-            }
-
-            // Add error message and let agent retry
-            this.messages.push({
-              role: "tool",
-              content: errorMessage + " Please try again.",
-            });
-            break; // Stop processing remaining tools, let agent retry
           }
+          toolCallsTotalTime = +(
+            (performance.now() - toolCallsStartTime) /
+            1000
+          ).toFixed(2);
         }
-        toolCallsTotalTime = +(
-          (performance.now() - toolCallsStartTime) /
-          1000
-        ).toFixed(2);
+
+        // agent should exit if there are no tools to call
+      } while (toolCalls.length > 0);
+      // or respond with a message
+      const lastMessage = this.messages[this.messages.length - 1];
+
+      if (lastMessage?.content) {
+        log.info("Assistant: ");
+        log.message(lastMessage.content, {
+          spacing: 0
+        });
       }
 
-      // agent should exit if there are no tools to call
-    } while (toolCalls.length > 0);
+      const solveTotalTime = +((performance.now() - solveStart) / 1000).toFixed(
+        2
+      );
+      thinkingSpinner.stop("Thinking done.");
+      log.info(
+        chalk.dim(`${iterationsCount} steps were made in ${solveTotalTime}s . ${toolCallsCount} tools were called in ${toolCallsTotalTime}s.`),
+      );
 
-    thinkingSpinner.stop("Thinking done.");
-    // or respond with a message
-    const lastMessage = this.messages[this.messages.length - 1];
-
-    if (lastMessage?.content) {
-      log.info("Assistant: ");
-      log.message(lastMessage.content, {
-        spacing: 0
+      logLocalResponse({
+        solve: {
+          modelId: this.config.modelId,
+          totalDuration: solveTotalTime,
+          toolCallsCount,
+          toolCallsTotalTime,
+          iterationsCount,
+        },
       });
+      return {
+        content: lastMessage?.content ?? null,
+        error: null,
+      };
+    } catch (error) {
+      thinkingSpinner.stop("");
+      return {
+        content: "Failed to solve the prompt.",
+        error: error instanceof Error ? error.message : `${error}`
+      }
     }
-
-    const solveTotalTime = +((performance.now() - solveStart) / 1000).toFixed(
-      2
-    );
-
-    log.info(
-      chalk.dim(`${iterationsCount} steps were made in ${solveTotalTime}s . ${toolCallsCount} tools were called in ${toolCallsTotalTime}s.`),
-    );
-    logLocalResponse({
-      solve: {
-        modelId: config.localAgent.modelId,
-        totalDuration: solveTotalTime,
-        toolCallsCount,
-        toolCallsTotalTime,
-        iterationsCount,
-      },
-    });
-
-    return {
-      content: lastMessage?.content ?? null,
-      error: null,
-    };
-    /** agent loop ends here */
   }
 
   formatToolResponse(toolResponse: CallToolResponse) {
@@ -271,15 +267,16 @@ export class LocalAgent {
     return String(content);
   }
 
-  async setModel(modelId: string) {
-    await this.cleanup();
-    await this.model?.setModel(modelId);
-    await this.connect();
+  updateConfig(config: McpConfig["providers"][string]) {
+    this.config = config;
   }
 
-  async cleanup() {
-    for (const client of Object.values(this.clients)) {
-      await client.disconnectFromServer();
-    }
+  async restartAgent(
+    newConfig: McpConfig["providers"][string],
+    oldConfig: McpConfig["providers"][string],
+  ) {
+    await this.stop();
+    this.updateConfig(newConfig)
+    await this.start();
   }
 }

--- a/agents/local-agent.ts
+++ b/agents/local-agent.ts
@@ -8,6 +8,7 @@ import { logLocalResponse } from "../lib/message-logger";
 import { LocalModel } from "../models/llm";
 import type { Message, Tool, ToolCall, ChatResponse } from "ollama";
 import type { AllowedDirs } from "../lib/get-dirs-from-args";
+import type { McpConfig } from "../config";
 
 export interface SolveResult {
   content: string | null;
@@ -22,7 +23,7 @@ export class LocalAgent {
   private toolMap: Map<string, Client>;
   public tools: Tool[] = [];
   private messages: Message[];
-  private config: Config;
+  private config: McpConfig;
   private allowedDirs: AllowedDirs;
 
   constructor({
@@ -31,7 +32,7 @@ export class LocalAgent {
     allowedDirs
   }: {
     instructions: string;
-    config: Config;
+    config: McpConfig;
     allowedDirs: AllowedDirs
   }) {
     this.allowedDirs = allowedDirs;
@@ -50,7 +51,7 @@ export class LocalAgent {
     });
   }
 
-  async connect(config: Config) {
+  async connect(config: McpConfig) {
     const startTime = performance.now();
     const { clients, toolMap, tools } = await connectToMCPServers(config, this.allowedDirs);
     this.clients = clients;

--- a/agents/remote-agent.ts
+++ b/agents/remote-agent.ts
@@ -1,4 +1,3 @@
-import { connectAISDKToMCPServers } from "../lib/connect-to-mcp-servers";
 import {
   Experimental_Agent as Agent,
   type ModelMessage,
@@ -9,127 +8,133 @@ import { log, spinner } from "@clack/prompts";
 import { logRemoteResponse } from "../lib/message-logger";
 import { groq } from "@ai-sdk/groq";
 import type { SolveResult } from "./local-agent";
-import type { AllowedDirs } from "../lib/get-dirs-from-args";
 import chalk from "chalk";
-import { getConfig } from "../lib/get-mcp-config";
+import type { McpConfig } from "../config-validation";
+import { connectAISDKToMCPServers, type ToolType } from "../lib/connect-to-mcp-servers";
+import type { AllowedDirs } from "../lib/get-dirs-from-args";
 
 export class RemoteAgent {
   private agent: any | null = null;
   private messages: ModelMessage[] = [];
-  private clients: Map<string, MCPClient> | null = null;
+  private tools: ToolType;
   private instructions: string;
-  private modelId: string;
-  private allowedDirs: AllowedDirs;
+  private config: McpConfig["providers"][number];
+
+  static async connectMCPServers(allowedDirs: AllowedDirs) {
+    return await connectAISDKToMCPServers(allowedDirs);
+  }
 
   constructor({
     instructions,
-    modelId,
-    allowedDirs
+    tools,
+    config,
   }: {
     instructions: string;
-    modelId: string;
-    allowedDirs: AllowedDirs
+    tools: ToolType
+    config: McpConfig["providers"][number];
   }) {
-    this.allowedDirs = allowedDirs;
     this.instructions = instructions;
-    this.modelId = modelId;
+    this.tools = tools;
+    this.config = config;
     // Nice to research: There are "structuredOutputs" that define how output looks like
   }
 
-  async connect() {
-    const config = await getConfig();
+  async start() {
     const startTime = performance.now();
-    const { tools, clients } = await connectAISDKToMCPServers(config, this.allowedDirs);
-    const warmupSpinner = spinner();
-    warmupSpinner.start(
-      `Warming up model ${config.remoteAgent.modelId} with ${Object.keys(tools).length} tools...`
-    );
     try {
-      this.clients = clients;
       this.agent = new Agent({
-        model: groq(this.modelId),
+        model: groq(this.config.modelId),
         system: this.instructions,
-        tools,
+        tools: this.tools,
         stopWhen: stepCountIs(10),
       });
       const connectTime = +((performance.now() - startTime) / 1000).toFixed(2);
       await logRemoteResponse({
         init: {
-          modelId: this.modelId,
+          modelId: this.config.modelId,
           totalDuration: connectTime,
         },
       });
-      warmupSpinner.stop(`Remote model ${config.remoteAgent.modelId} ready.`);
+      log.message(`Remote model ${this.config.modelId} ready, with ${Object.keys(this.tools).length} tools...`);
     } catch (error) {
       const errorMessage = `Failed to initialize remote agent: ${error instanceof Error ? error.message : String(error)}`;
-      warmupSpinner.stop("");
       log.error(errorMessage);
       throw new Error(errorMessage);
     }
   }
 
+  async stop() {
+    this.agent = null;
+  }
+
   async solve(prompt: string): Promise<SolveResult> {
     const startTime = performance.now();
+    const solveSpinner = spinner();
+    solveSpinner.start("Solving");
     // save context
     this.messages.push({
       role: "user",
       content: prompt,
     });
-    const solveSpinner = spinner();
-    solveSpinner.start("Solving.");
-    /*
-      - Automatically handles the tool-calling loop
-      - Decides when to call tools vs respond
-      - Manages multiple iterations internally
-    */
-    const response = await this.agent.generate({
-      messages: this.messages,
-    });
-    // respond and save context
-    if (response.text) {
-      this.messages.push({
-        role: "assistant",
-        content: response.text,
+    try {
+      /*
+        - Automatically handles the tool-calling loop
+        - Decides when to call tools vs respond
+        - Manages multiple iterations internally
+      */
+      const response = await this.agent.generate({
+        messages: this.messages,
       });
-      solveSpinner.stop(`Solved.`);
+      // respond and save context
+      if (response.text) {
+        this.messages.push({
+          role: "assistant",
+          content: response.text,
+        });
+        solveSpinner.stop(`Solved`);
 
-      log.info("Assistant: ");
-      log.message(response.text, {
-        spacing: 0
-      });
+        log.info("Assistant: ");
+        log.message(response.text, {
+          spacing: 0
+        });
+      }
+      // log response
+      logRemoteResponse({ response });
+
+      // Check if there was an error
+      const error =
+        response.finishReason === "error"
+          ? "Agent encountered an error"
+          : response.finishReason === "step-limit"
+            ? "Max iterations reached"
+            : null;
+
+      const totalTime = +((performance.now() - startTime) / 1000).toFixed(2);
+      log.info(chalk.dim(`Assistant needed ${totalTime}s to complete.`));
+
+      return {
+        content: response.text ?? null,
+        error,
+      };
+    } catch (error) {
+      solveSpinner.stop("");
+      return {
+        content: "Failed to solve the prompt.",
+        error: error instanceof Error ? error.message : `${error}`
+      }
     }
-    // log response
-    logRemoteResponse({ response });
-
-    // Check if there was an error
-    const error =
-      response.finishReason === "error"
-        ? "Agent encountered an error"
-        : response.finishReason === "step-limit"
-          ? "Max iterations reached"
-          : null;
-
-    const totalTime = +((performance.now() - startTime) / 1000).toFixed(2);
-    log.info(chalk.dim(`Assistant needed ${totalTime}s to complete.`));
-
-    return {
-      content: response.text ?? null,
-      error,
-    };
   }
 
-  async setModel(modelId: string) {
-    await this.cleanup();
-    this.modelId = modelId;
-    await this.connect();
+  updateConfig(config: McpConfig["providers"][string]) {
+    this.config = config;
   }
 
-  async cleanup() {
-    if (this.clients === null) {
-      return;
-    }
-    await Promise.all(
-      Object.values(this.clients).map((client) => client.close())
-    );
+  async restartAgent(
+    newConfig: McpConfig["providers"][string],
+    oldConfig: McpConfig["providers"][string],
+  ) {
+    await this.stop();
+    this.updateConfig(newConfig);
+    await this.start();
   }
 }

--- a/agents/remote-agent.ts
+++ b/agents/remote-agent.ts
@@ -74,6 +74,8 @@ export class RemoteAgent {
       role: "user",
       content: prompt,
     });
+    const solveSpinner = spinner();
+    solveSpinner.start("Solving.");
     /*
       - Automatically handles the tool-calling loop
       - Decides when to call tools vs respond
@@ -88,6 +90,8 @@ export class RemoteAgent {
         role: "assistant",
         content: response.text,
       });
+      solveSpinner.stop(`Solved.`);
+
       log.info("Assistant: ");
       log.message(response.text, {
         spacing: 0

--- a/agents/remote-agent.ts
+++ b/agents/remote-agent.ts
@@ -12,6 +12,7 @@ import type { Config } from "../lib/get-mcp-config";
 import type { SolveResult } from "./local-agent";
 import type { AllowedDirs } from "../lib/get-dirs-from-args";
 import chalk from "chalk";
+import type { McpConfig } from "../config";
 
 export class RemoteAgent {
   private agent: any | null = null;
@@ -36,7 +37,7 @@ export class RemoteAgent {
     // Nice to research: There are "structuredOutputs" that define how output looks like
   }
 
-  async connect(config: Config) {
+  async connect(config: McpConfig) {
     const startTime = performance.now();
     const { tools, clients } = await connectAISDKToMCPServers(config, this.allowedDirs);
     const warmupSpinner = spinner();

--- a/agents/remote-agent.ts
+++ b/agents/remote-agent.ts
@@ -8,11 +8,10 @@ import {
 import { log, spinner } from "@clack/prompts";
 import { logRemoteResponse } from "../lib/message-logger";
 import { groq } from "@ai-sdk/groq";
-import type { Config } from "../lib/get-mcp-config";
 import type { SolveResult } from "./local-agent";
 import type { AllowedDirs } from "../lib/get-dirs-from-args";
 import chalk from "chalk";
-import type { McpConfig } from "../config";
+import { getConfig } from "../lib/get-mcp-config";
 
 export class RemoteAgent {
   private agent: any | null = null;
@@ -37,7 +36,8 @@ export class RemoteAgent {
     // Nice to research: There are "structuredOutputs" that define how output looks like
   }
 
-  async connect(config: McpConfig) {
+  async connect() {
+    const config = await getConfig();
     const startTime = performance.now();
     const { tools, clients } = await connectAISDKToMCPServers(config, this.allowedDirs);
     const warmupSpinner = spinner();
@@ -116,6 +116,12 @@ export class RemoteAgent {
       content: response.text ?? null,
       error,
     };
+  }
+
+  async setModel(modelId: string) {
+    await this.cleanup();
+    this.modelId = modelId;
+    await this.connect();
   }
 
   async cleanup() {

--- a/benchmarks/host-benchmark.ts
+++ b/benchmarks/host-benchmark.ts
@@ -6,9 +6,9 @@ import { LocalAgent } from "../agents/local-agent";
 import { RemoteAgent } from "../agents/remote-agent";
 import { BunnyNetApi } from "../servers/cdn/bunnynet";
 import type { IBunnyNetAPIInterface } from "../servers/cdn/bunnynet";
-import { getConfig, type Config } from "../lib/get-mcp-config";
+import { getConfig } from "../lib/get-mcp-config";
 import type { file as BunnyFileNamespace } from "@bunny.net/storage-sdk";
-import type { McpConfig } from "../config";
+import type { McpConfig } from "../config-validation";
 
 const PROMPT = "Generate 2 facts about oranges and upload as oranges.txt.";
 const DEFAULT_ITERATIONS = 5;
@@ -88,13 +88,13 @@ interface BenchmarkSummary {
 async function main() {
   const config = await getConfig();
   const options = parseOptions();
-  const assetsDirectory = resolveAssetsDirectory(config!);
+  const assetsDirectory = resolveAssetsDirectory(config);
   const bunnyApi = new BunnyNetApi();
   const results: IterationResult[] = [];
 
   console.log(
     `Running host benchmark for ${options.iterations} iteration${options.iterations === 1 ? "" : "s"
-    } using ${config?.agentProvider}`
+    } using ${config.agentProvider}`
   );
 
   for (let index = 0; index < options.iterations; index++) {
@@ -107,7 +107,7 @@ async function main() {
       api: bunnyApi,
     });
 
-    const { agent, provider, modelId } = createAgent(config!);
+    const { agent, provider, modelId } = createAgent(config);
     const startedAt = new Date();
     const localFilesBefore = await listLocalFiles(assetsDirectory);
     const startTime = performance.now();
@@ -116,7 +116,7 @@ async function main() {
     let solveError: string | null = null;
 
     try {
-      await agent.connect(config!);
+      await agent.connect();
       const result = await agent.solve(options.prompt);
       solveContent = result.content;
       solveError = result.error;
@@ -221,11 +221,11 @@ async function main() {
     iterations: options.iterations,
     prompt: options.prompt,
     assetsDirectory,
-    agentProvider: config?.agentProvider,
+    agentProvider: config.agentProvider,
     modelId:
-      config?.agentProvider === "remoteAgent"
-        ? config?.remoteAgent.modelId
-        : config?.localAgent.modelId,
+      config.agentProvider === "remoteAgent"
+        ? config.remoteAgent.modelId
+        : config.localAgent.modelId,
     results,
   };
 

--- a/benchmarks/host-benchmark.ts
+++ b/benchmarks/host-benchmark.ts
@@ -8,6 +8,7 @@ import { BunnyNetApi } from "../servers/cdn/bunnynet";
 import type { IBunnyNetAPIInterface } from "../servers/cdn/bunnynet";
 import { getConfig, type Config } from "../lib/get-mcp-config";
 import type { file as BunnyFileNamespace } from "@bunny.net/storage-sdk";
+import type { McpConfig } from "../config";
 
 const PROMPT = "Generate 2 facts about oranges and upload as oranges.txt.";
 const DEFAULT_ITERATIONS = 5;
@@ -87,13 +88,13 @@ interface BenchmarkSummary {
 async function main() {
   const config = await getConfig();
   const options = parseOptions();
-  const assetsDirectory = resolveAssetsDirectory(config);
+  const assetsDirectory = resolveAssetsDirectory(config!);
   const bunnyApi = new BunnyNetApi();
   const results: IterationResult[] = [];
 
   console.log(
     `Running host benchmark for ${options.iterations} iteration${options.iterations === 1 ? "" : "s"
-    } using ${config.agentProvider}`
+    } using ${config?.agentProvider}`
   );
 
   for (let index = 0; index < options.iterations; index++) {
@@ -106,7 +107,7 @@ async function main() {
       api: bunnyApi,
     });
 
-    const { agent, provider, modelId } = createAgent(config);
+    const { agent, provider, modelId } = createAgent(config!);
     const startedAt = new Date();
     const localFilesBefore = await listLocalFiles(assetsDirectory);
     const startTime = performance.now();
@@ -115,7 +116,7 @@ async function main() {
     let solveError: string | null = null;
 
     try {
-      await agent.connect(config);
+      await agent.connect(config!);
       const result = await agent.solve(options.prompt);
       solveContent = result.content;
       solveError = result.error;
@@ -220,11 +221,11 @@ async function main() {
     iterations: options.iterations,
     prompt: options.prompt,
     assetsDirectory,
-    agentProvider: config.agentProvider,
+    agentProvider: config?.agentProvider,
     modelId:
-      config.agentProvider === "remoteAgent"
-        ? config.remoteAgent.modelId
-        : config.localAgent.modelId,
+      config?.agentProvider === "remoteAgent"
+        ? config?.remoteAgent.modelId
+        : config?.localAgent.modelId,
     results,
   };
 
@@ -267,7 +268,7 @@ function getArgValue(args: string[], key: string): string | undefined {
   return undefined;
 }
 
-function resolveAssetsDirectory(config: Config): string {
+function resolveAssetsDirectory(config: McpConfig): string {
   const filesystemServer = config.mcpServers["filesystem"];
   if (!filesystemServer) {
     throw new Error("Filesystem MCP server not configured in mcp-config.json");
@@ -290,7 +291,7 @@ function resolveAssetsDirectory(config: Config): string {
   return assetsPath;
 }
 
-function createAgent(config: Config): {
+function createAgent(config: McpConfig): {
   agent: UplinkAgent;
   provider: AgentProvider;
   modelId: string;

--- a/benchmarks/host-benchmark.ts
+++ b/benchmarks/host-benchmark.ts
@@ -9,6 +9,7 @@ import type { IBunnyNetAPIInterface } from "../servers/cdn/bunnynet";
 import { getConfig } from "../lib/get-mcp-config";
 import type { file as BunnyFileNamespace } from "@bunny.net/storage-sdk";
 import type { McpConfig } from "../config-validation";
+import type { UplinkAgent } from "../lib/host-agent";
 
 const PROMPT = "Generate 2 facts about oranges and upload as oranges.txt.";
 const DEFAULT_ITERATIONS = 5;
@@ -33,7 +34,6 @@ You are able to chain tools. For example, create file locally, upload to cloud.
 `;
 
 type StorageFile = BunnyFileNamespace.StorageFile;
-type UplinkAgent = LocalAgent | RemoteAgent;
 type AgentProvider = "localAgent" | "remoteAgent";
 
 interface BenchmarkOptions {

--- a/benchmarks/tool-benchmark.ts
+++ b/benchmarks/tool-benchmark.ts
@@ -13,6 +13,7 @@ import { Client } from "../client/client";
 import { LocalModel } from "../models/llm";
 import { GroqModel } from "../models/groq";
 import { getConfig, type Config } from "../lib/get-mcp-config";
+import type { McpConfig } from "../config";
 
 type ProviderOption = "local" | "remote";
 
@@ -137,7 +138,7 @@ async function main() {
   });
 }
 
-function parseOptions(config: Config): BenchmarkOptions {
+function parseOptions(config: McpConfig): BenchmarkOptions {
   const args = Bun.argv.slice(2);
 
   const providersArg =
@@ -162,9 +163,9 @@ function parseOptions(config: Config): BenchmarkOptions {
     getArgValue(args, "--tool-counts") ?? getArgValue(args, "--tool-count");
   const toolCounts = toolCountsArg
     ? toolCountsArg
-        .split(",")
-        .map((value) => Number(value.trim()))
-        .filter((value) => Number.isFinite(value) && value > 0)
+      .split(",")
+      .map((value) => Number(value.trim()))
+      .filter((value) => Number.isFinite(value) && value > 0)
     : DEFAULT_TOOL_COUNTS;
   if (toolCounts.length === 0) {
     throw new Error("No valid tool counts provided.");
@@ -214,7 +215,7 @@ async function runLocalBenchmark({
   toolCounts,
   samples,
 }: {
-  config: Config;
+  config: McpConfig;
   toolCounts: number[];
   samples: number;
 }): Promise<ProviderSummary> {
@@ -253,8 +254,7 @@ async function runLocalBenchmark({
     for (let index = 0; index < samples; index++) {
       try {
         console.log(
-          `[Local] Running sample ${
-            index + 1
+          `[Local] Running sample ${index + 1
           }/${samples} for ${toolCount} tools...`
         );
         const sample = await runLocalSample({
@@ -264,8 +264,7 @@ async function runLocalBenchmark({
         });
         samplesForCount.push({ ...sample, sampleIndex: index + 1 });
         console.log(
-          `[Local] Completed sample ${index + 1}/${samples} (wall: ${
-            sample.wallTimeSeconds
+          `[Local] Completed sample ${index + 1}/${samples} (wall: ${sample.wallTimeSeconds
           }s)`
         );
       } catch (error) {
@@ -304,7 +303,7 @@ async function runRemoteBenchmark({
   toolCounts,
   samples,
 }: {
-  config: Config;
+  config: McpConfig;
   toolCounts: number[];
   samples: number;
 }): Promise<ProviderSummary> {
@@ -343,8 +342,7 @@ async function runRemoteBenchmark({
     for (let index = 0; index < samples; index++) {
       try {
         console.log(
-          `[Remote] Running sample ${
-            index + 1
+          `[Remote] Running sample ${index + 1
           }/${samples} for ${toolCount} tools...`
         );
         const sample = await runRemoteSample({
@@ -354,8 +352,7 @@ async function runRemoteBenchmark({
         });
         samplesForCount.push({ ...sample, sampleIndex: index + 1 });
         console.log(
-          `[Remote] Completed sample ${index + 1}/${samples} (wall: ${
-            sample.wallTimeSeconds
+          `[Remote] Completed sample ${index + 1}/${samples} (wall: ${sample.wallTimeSeconds
           }s)`
         );
       } catch (error) {
@@ -654,8 +651,7 @@ function renderTextSummary(summaries: ProviderSummary[], prompts: string[]) {
         toolSummary.averageOutputTokens !== null
       ) {
         console.log(
-          `    avg tokens: input=${
-            toolSummary.averageInputTokens ?? "n/a"
+          `    avg tokens: input=${toolSummary.averageInputTokens ?? "n/a"
           }, output=${toolSummary.averageOutputTokens ?? "n/a"}`
         );
       }

--- a/benchmarks/tool-benchmark.ts
+++ b/benchmarks/tool-benchmark.ts
@@ -12,8 +12,8 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { Client } from "../client/client";
 import { LocalModel } from "../models/llm";
 import { GroqModel } from "../models/groq";
-import { getConfig, type Config } from "../lib/get-mcp-config";
-import type { McpConfig } from "../config";
+import { getConfig } from "../lib/get-mcp-config";
+import type { McpConfig } from "../config-validation";
 
 type ProviderOption = "local" | "remote";
 

--- a/bun.lock
+++ b/bun.lock
@@ -2,7 +2,7 @@
   "lockfileVersion": 1,
   "workspaces": {
     "": {
-      "name": "wip-bachelors",
+      "name": "uplink",
       "dependencies": {
         "@ai-sdk/groq": "^2.0.20",
         "@bunny.net/edgescript-sdk": "^0.12.0",
@@ -31,67 +31,61 @@
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@1.1.0-beta.19", "", { "dependencies": { "@ai-sdk/provider": "2.1.0-beta.5", "@ai-sdk/provider-utils": "3.1.0-beta.9", "@vercel/oidc": "^3.0.1" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-O/XD8KdVrMIt/S7l+0QqdiyCL2PEC2CGM8i31bn/5P2JsPMdfDI9LX/VK4lLWNfuWCQePFnmiondnYnoqKF+Hg=="],
 
-    "@ai-sdk/groq": ["@ai-sdk/groq@2.0.28", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.16" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-910ACt1kUA6+en9hjfhQFo+/yaUDe3xaAf7+l2N6jrfUNNciHe5DoW0GAJwGMnYK2li9CVcWNNXsmQ6TCzPnDA=="],
+    "@ai-sdk/groq": ["@ai-sdk/groq@2.0.36", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.22" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-rOn7b3VzebDIwY7/daSXEvYG/M4fNEQJ5cwJWTu8rImhf87P8FJaJNSlI5HUej8u+UVhQmi8ShtQdAGnoXD9pA=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.16", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-lsWQY9aDXHitw7C1QRYIbVGmgwyT98TF3MfM8alNIXKpdJdi+W782Rzd9f1RyOfgRmZ08gJ2EYNDhWNK7RqpEA=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.22", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-fFT1KfUUKktfAFm5mClJhS1oux9tP2qgzmEZVl5UdwltQ1LO/s8hd7znVrgKzivwv1s1FIPza0s9OpJaNB/vHw=="],
 
-    "@borewit/text-codec": ["@borewit/text-codec@0.1.1", "", {}, "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA=="],
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 
-    "@bunny.net/edgescript-sdk": ["@bunny.net/edgescript-sdk@0.12.0", "", { "dependencies": { "@hono/node-server": "^1.12.0", "hono": "^4.5.5" } }, "sha512-SLXBnPjxj1zNchNaGT2n8j5JWHzzfEYvpv4k3o1Cg1u4tAsnqzdmV7jTajLgFPdaJBdgrzuWzYXgDNqR51Ad2Q=="],
+    "@bunny.net/edgescript-sdk": ["@bunny.net/edgescript-sdk@0.12.1", "", { "dependencies": { "@hono/node-server": "^1.12.0", "hono": "^4.5.5" } }, "sha512-+B+AUnfA+9y6PlyX6BNL2Uk8x3vExRIKKP+rH0r4UnEWRiJZsbuEnZg5Au6pglf67NumP8tOwbrqP9jS4e+jDQ=="],
 
-    "@bunny.net/storage-sdk": ["@bunny.net/storage-sdk@0.3.0", "", { "dependencies": { "dotenv": "^16.4.7", "zod": "^3.24.2" } }, "sha512-fRtYdztE01tVdQFX25GlYYnjCeTrW44ZsVlUNOcczKzPg6ellZ/awCzg+WsqY7bwIlUD7dTgy/Jtj8qOTmAs+Q=="],
+    "@bunny.net/storage-sdk": ["@bunny.net/storage-sdk@0.3.1", "", { "dependencies": { "dotenv": "^16.4.7", "zod": "^3.24.2" } }, "sha512-nHD+e+CxYBcSoZERkxI/7Qir/kZaCfBTT+ULgZNUitNSyZ4mWD3DbTy+sHwVfRyc6wQ0XYD//6LImi2PU9JoWg=="],
 
     "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
 
     "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 
-    "@hono/node-server": ["@hono/node-server@1.15.0", "", { "peerDependencies": { "hono": "^4" } }, "sha512-MjmK4l5N4dQpZ9OSWN0tCj7ejuc7WvuWMzSKtc89bnknJykAeHxzRigXBTYZk85H6Awrii6RM59iUiUluApu2A=="],
-
-    "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
-
-    "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
+    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.21.0", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-YFBsXJMFCyI1zP98u7gezMFKX4lgu/XpoZJk7ufI6UlFKXLj2hAMUuRlQX/nrmIPOmhRrG6tw2OQ2ZA/ZlXYpQ=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
-    "@modelcontextprotocol/server-filesystem": ["@modelcontextprotocol/server-filesystem@2025.8.21", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.17.0", "diff": "^5.1.0", "glob": "^10.3.10", "minimatch": "^10.0.1", "zod-to-json-schema": "^3.23.5" }, "bin": { "mcp-server-filesystem": "dist/index.js" } }, "sha512-Kk+E+lAuAQPLhrJlrsboEdwTBxWU0DYfsuELIuP3Nvfn8Kvd72BU6KVjhEa5EjbC4YckQDCxH9VJK47x6psxow=="],
+    "@modelcontextprotocol/server-filesystem": ["@modelcontextprotocol/server-filesystem@2025.12.18", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.24.0", "diff": "^5.1.0", "glob": "^10.5.0", "minimatch": "^10.0.1", "zod-to-json-schema": "^3.23.5" }, "bin": { "mcp-server-filesystem": "dist/index.js" } }, "sha512-wg3nn5L5xOdMGlPb1nAFknS3bjxJJEWKgzhDAHKf+i65r9WbxyluyCm66hx1hOcV9qZZH9twzroRHRQprJxQ7w=="],
 
-    "@openai/agents": ["@openai/agents@0.1.2", "", { "dependencies": { "@openai/agents-core": "0.1.2", "@openai/agents-openai": "0.1.2", "@openai/agents-realtime": "0.1.2", "debug": "^4.4.0", "openai": "^5.16.0" }, "peerDependencies": { "zod": "^3.25.40" } }, "sha512-ozqikDIxYgMDh3CFbVaaFRBWK7rIr+JXyULtFLi9HhVPej8H0+ofkKa/VOJpf2oRL09scc4aJXpRNY/7uIQ+DQ=="],
+    "@openai/agents": ["@openai/agents@0.1.11", "", { "dependencies": { "@openai/agents-core": "0.1.11", "@openai/agents-openai": "0.1.11", "@openai/agents-realtime": "0.1.11", "debug": "^4.4.0", "openai": "^5.20.2" }, "peerDependencies": { "zod": "^3.25.40" } }, "sha512-jnaFt54iP71vYDXvpG3EGX2kVRYIU2xBdCT3uFqdXm4KqFAP9JQFNGiKKBEeE5rbXARpqAQpKH+5HfoANndpcQ=="],
 
-    "@openai/agents-core": ["@openai/agents-core@0.1.2", "", { "dependencies": { "debug": "^4.4.0", "openai": "^5.16.0" }, "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.17.2" }, "peerDependencies": { "zod": "^3.25.40" }, "optionalPeers": ["zod"] }, "sha512-i/6w8MLq1fPeAumQkkqn/UT63MEpZLBTYuarHVYeB3ISmdz5L7pbMLsvEwBKZWfAgDjDOHry6YYrpYB5aYi97w=="],
+    "@openai/agents-core": ["@openai/agents-core@0.1.11", "", { "dependencies": { "debug": "^4.4.0", "openai": "^5.20.2" }, "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.17.2" }, "peerDependencies": { "zod": "^3.25.40" }, "optionalPeers": ["zod"] }, "sha512-ye8VIAO2wPIg1zClldIj8We/1R55VmdgnMyn0g4YGbp6RD5Wpv9yfH5kPNWxmHvw8ji+XehyggGoklY4FGQoBQ=="],
 
-    "@openai/agents-openai": ["@openai/agents-openai@0.1.2", "", { "dependencies": { "@openai/agents-core": "0.1.2", "debug": "^4.4.0", "openai": "^5.16.0" }, "peerDependencies": { "zod": "^3.25.40" } }, "sha512-G1sasOYBdTvODDNdd9NW9939npp+StqjrS0QOQdmfb9DQRIA7LLN/9zUe73a60APziNPl1lqJrfClDcW8g+ODw=="],
+    "@openai/agents-openai": ["@openai/agents-openai@0.1.11", "", { "dependencies": { "@openai/agents-core": "0.1.11", "debug": "^4.4.0", "openai": "^5.20.2" }, "peerDependencies": { "zod": "^3.25.40" } }, "sha512-TYYbY7o1cNxtOIO4F1a20qkqDT1Iwr9ZEi0MO2sEaeioK8rGB/Ux54iFvsA3IblUYyK+5fD25vr4vXFasvg2Kg=="],
 
-    "@openai/agents-realtime": ["@openai/agents-realtime@0.1.2", "", { "dependencies": { "@openai/agents-core": "0.1.2", "@types/ws": "^8.18.1", "debug": "^4.4.0", "ws": "^8.18.1" }, "peerDependencies": { "zod": "^3.25.40" } }, "sha512-jXC0AfaJJnfCR8zDp26eBEkGB2xkmgKQb2w+WiK+rsw0pPmIbrY97yqWJPLQC/C0s2DAy8oeL21msrETr/amdg=="],
+    "@openai/agents-realtime": ["@openai/agents-realtime@0.1.11", "", { "dependencies": { "@openai/agents-core": "0.1.11", "@types/ws": "^8.18.1", "debug": "^4.4.0", "ws": "^8.18.1" }, "peerDependencies": { "zod": "^3.25.40" } }, "sha512-8jaNuYU1acra28i7bYrZIPubI6s2ziY2ZudqAVK2ad+giopXcrNSiJTuZ2S3z+ESnIejwMiYLfnY2Le8W0SJ7A=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@tokenizer/inflate": ["@tokenizer/inflate@0.2.7", "", { "dependencies": { "debug": "^4.4.0", "fflate": "^0.8.2", "token-types": "^6.0.0" } }, "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg=="],
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
-    "@types/bun": ["@types/bun@1.2.18", "", { "dependencies": { "bun-types": "1.2.18" } }, "sha512-Xf6RaWVheyemaThV0kUfaAUvCNokFr+bH8Jxp+tTZfx7dAPA8z9ePnP9S9+Vspzuxxx9JRAXhnyccRj3GyCMdQ=="],
+    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
-    "@types/node": ["@types/node@24.0.13", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ=="],
-
-    "@types/react": ["@types/react@19.1.8", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g=="],
+    "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
-    "@vercel/oidc": ["@vercel/oidc@3.0.3", "", {}, "sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg=="],
+    "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "ai": ["ai@5.1.0-beta.28", "", { "dependencies": { "@ai-sdk/gateway": "1.1.0-beta.19", "@ai-sdk/provider": "2.1.0-beta.5", "@ai-sdk/provider-utils": "3.1.0-beta.9", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MMGM5h3hB2ty9aeOYKyYkhdy8SW298Bgo3k+388+mfgAPbJUDOzIexnk6KynUXHwls5y/tUBafHe0v2YAupPbg=="],
 
-    "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
@@ -99,13 +93,13 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
-    "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+    "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
-    "bun-types": ["bun-types@1.2.18", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-04+Eha5NP7Z0A9YgDAzMk5PHR16ZuLVa83b26kH5+cp1qZW4F6FmAURngE7INf4tKOvCE69vYvDEwoNl1tGiWw=="],
+    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -119,7 +113,7 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "content-disposition": ["content-disposition@1.0.0", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg=="],
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
@@ -127,19 +121,17 @@
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
-    "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
-
-    "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
-    "diff": ["diff@5.2.0", "", {}, "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A=="],
+    "diff": ["diff@5.2.2", "", {}, "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A=="],
 
-    "dotenv": ["dotenv@17.2.2", "", {}, "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q=="],
+    "dotenv": ["dotenv@17.3.1", "", {}, "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -163,23 +155,19 @@
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
-    "eventsource-parser": ["eventsource-parser@3.0.3", "", {}, "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA=="],
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
-    "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
-    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+    "express-rate-limit": ["express-rate-limit@8.3.0", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
-
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
-    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+    "file-type": ["file-type@21.3.0", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.4", "token-types": "^6.1.1", "uint8array-extras": "^1.4.0" } }, "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA=="],
 
-    "file-type": ["file-type@21.0.0", "", { "dependencies": { "@tokenizer/inflate": "^0.2.7", "strtok3": "^10.2.2", "token-types": "^6.0.0", "uint8array-extras": "^1.4.0" } }, "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg=="],
-
-    "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
@@ -193,7 +181,7 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
-    "glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -201,15 +189,17 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
-    "hono": ["hono@4.8.4", "", {}, "sha512-KOIBp1+iUs0HrKztM4EHiB2UtzZDTBihDtOF5K6+WaJjCPeaW4Q92R8j63jOhvJI5+tZSMuKD9REVEXXY9illg=="],
+    "hono": ["hono@4.12.5", "", {}, "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg=="],
 
-    "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
@@ -221,9 +211,13 @@
 
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
+    "jose": ["jose@6.2.0", "", {}, "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ=="],
+
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -235,11 +229,11 @@
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
-    "mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "minimatch": ["minimatch@10.0.3", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw=="],
+    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
-    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -249,13 +243,13 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
-    "ollama": ["ollama@0.6.2", "", { "dependencies": { "whatwg-fetch": "^3.6.20" } }, "sha512-VcPZpBuz3kdoJIcyWpiDS1MSDSZKyQPM6f9wi405vdLOB5yZWiQ+m7NSTrYsntQyCp/s/Yy0quKiYerhq7Liog=="],
+    "ollama": ["ollama@0.6.3", "", { "dependencies": { "whatwg-fetch": "^3.6.20" } }, "sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg=="],
 
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "openai": ["openai@5.20.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-ZeBIEazj6W/XOulMw92L8iU5FblQeM5IxjPRCZNVArNXsoF+bLPnS7B2X4O0JSmpCM+F5Gdajr6bn4nAUj4LFQ=="],
+    "openai": ["openai@5.23.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg=="],
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
@@ -265,31 +259,27 @@
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
-    "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
-    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
-
-    "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
-    "raw-body": ["raw-body@3.0.0", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.6.3", "unpipe": "1.0.0" } }, "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g=="],
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
-    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "send": ["send@1.2.0", "", { "dependencies": { "debug": "^4.3.5", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.0", "mime-types": "^3.0.1", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.1" } }, "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw=="],
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
-    "serve-static": ["serve-static@2.2.0", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ=="],
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -309,13 +299,13 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
-    "statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
-    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -323,19 +313,17 @@
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
-    "token-types": ["token-types@6.1.1", "", { "dependencies": { "@borewit/text-codec": "^0.1.0", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ=="],
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
-    "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
+    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
-    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -349,29 +337,23 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@2.1.0-beta.5", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-gu/aV+8iTb0IjHmFO6eDuevp4E0fbtXqSj0RcKPttgedAbWY3uMe+vVgfe/j3bfbQfN7FjGkFDLS0xIirga7pA=="],
 
     "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.1.0-beta.9", "", { "dependencies": { "@ai-sdk/provider": "2.1.0-beta.5", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-WlKYWOP0bVWadrzKCWE9FcTTCYyNjR/8lTCIaFea1wiqZ+uqgC+91vcC0wtwuAyHr306o/bgeAZxRq8gF/0SMg=="],
 
-    "@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
-
     "@bunny.net/storage-sdk/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
-
-    "@modelcontextprotocol/server-filesystem/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.18.0", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-JvKyB6YwS3quM+88JPR0axeRgvdDu3Pv6mdZUy+w4qVkCzGgumb9bXG/TmtDRQv+671yaofVfXSQmFLlWU5qPQ=="],
-
-    "@openai/agents-core/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.18.0", "", { "dependencies": { "ajv": "^6.12.6", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" } }, "sha512-JvKyB6YwS3quM+88JPR0axeRgvdDu3Pv6mdZUy+w4qVkCzGgumb9bXG/TmtDRQv+671yaofVfXSQmFLlWU5qPQ=="],
 
     "ai/@ai-sdk/provider": ["@ai-sdk/provider@2.1.0-beta.5", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-gu/aV+8iTb0IjHmFO6eDuevp4E0fbtXqSj0RcKPttgedAbWY3uMe+vVgfe/j3bfbQfN7FjGkFDLS0xIirga7pA=="],
 
     "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.1.0-beta.9", "", { "dependencies": { "@ai-sdk/provider": "2.1.0-beta.5", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-WlKYWOP0bVWadrzKCWE9FcTTCYyNjR/8lTCIaFea1wiqZ+uqgC+91vcC0wtwuAyHr306o/bgeAZxRq8gF/0SMg=="],
 
-    "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -385,13 +367,7 @@
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "@ai-sdk/gateway/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
-
-    "@modelcontextprotocol/server-filesystem/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
-
-    "@openai/agents-core/@modelcontextprotocol/sdk/ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
-
-    "ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -399,8 +375,6 @@
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "@modelcontextprotocol/server-filesystem/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "@openai/agents-core/@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }
 }

--- a/client/client.ts
+++ b/client/client.ts
@@ -20,21 +20,6 @@ export class Client {
       {
         name: `ollama-client-${serverName}`,
         version: "1.0.0",
-      },
-      {
-        capabilities: {
-          tools: {
-            call: {
-              listChanged: true,
-            },
-            list: {
-              listChanged: true,
-            },
-          },
-          resources: {
-            listChanged: true,
-          },
-        },
       }
     );
 

--- a/config-validation.test.ts
+++ b/config-validation.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { agentSchema, configSchema, mcpServerSchema, validateMcpConfig } from "./config-validation";
+
+describe("mcpServerSchema", () => {
+  test("accepts valid MCP server config", () => {
+    const valid = {
+      command: "bun",
+      args: ["run", "servers/cdn/uplink-server.ts"],
+      vargs: ["/data"],
+      env: { NODE_ENV: "test" },
+      roots: [{ uri: "file:///data", name: "data-root" }],
+    };
+    expect(mcpServerSchema.parse(valid)).toEqual(valid);
+  });
+
+  test("rejects missing command or args or vargs", () => {
+    expect(() =>
+      mcpServerSchema.parse({
+        // command missing
+        args: ["run"],
+        vargs: [],
+      } as any),
+    ).toThrow();
+
+    expect(() =>
+      mcpServerSchema.parse({
+        command: "bun",
+        args: [],
+        vargs: [],
+      }),
+    ).toThrow();
+
+    expect(() =>
+      mcpServerSchema.parse({
+        command: "bun",
+        args: ["run"],
+        // vargs missing
+      } as any),
+    ).toThrow();
+  });
+});
+
+describe("agentSchema", () => {
+  test("accepts valid agent config", () => {
+    const valid = {
+      host: "http://localhost:11434",
+      modelId: "llama3",
+      models: ["llama3", "llama3:instruct"],
+    };
+    expect(agentSchema.parse(valid)).toEqual(valid);
+  });
+
+  test("requires non-empty models array and modelId", () => {
+    expect(() =>
+      agentSchema.parse({
+        host: "http://localhost:11434",
+        modelId: "",
+        models: ["llama3"],
+      }),
+    ).toThrow();
+
+    expect(() =>
+      agentSchema.parse({
+        host: "http://localhost:11434",
+        modelId: "llama3",
+        models: [],
+      }),
+    ).toThrow();
+  });
+});
+
+describe("configSchema / validateMcpConfig", () => {
+  const baseConfig = {
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem"],
+        vargs: ["/tmp"],
+      },
+    },
+    providers: {
+      localAgent: {
+        host: "http://localhost:11434",
+        modelId: "llama3",
+        models: ["llama3"],
+      },
+    },
+    agentProvider: "localAgent",
+    isChatEnabled: true,
+  } as const;
+
+  test("validateMcpConfig parses a valid config", () => {
+    const parsed = validateMcpConfig(baseConfig);
+    expect(parsed).toEqual(baseConfig);
+  });
+
+  test("rejects config when agentProvider is not a key of providers", () => {
+    const bad = {
+      ...baseConfig,
+      agentProvider: "remoteAgent",
+    };
+    expect(() => configSchema.parse(bad)).toThrow(/agentProvider must be a key of providers/);
+  });
+});
+

--- a/config-validation.ts
+++ b/config-validation.ts
@@ -22,21 +22,30 @@ export const agentSchema = z.object({
   models: z.array(z.string().min(1, "Missing a proper model name.")).describe("The list of available model identifiers that the agent can use.").min(1)
 });
 
-export const providerOptionSchema = z.enum(["localAgent", "remoteAgent"]);
+export const providersSchema = z.record(agentSchema);
 
 export const configSchema = z.object({
   mcpServers: z.record(mcpServerSchema),
-  localAgent: agentSchema,
-  remoteAgent: agentSchema,
-  agentProvider: providerOptionSchema,
+  providers: providersSchema,
+  agentProvider: z.string(),
   isChatEnabled: z.boolean()
+}).superRefine((cfg, ctx) => {
+  if (!(Object.hasOwn(cfg.providers, cfg.agentProvider))) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["agentProvider"],
+      message: "agentProvider must be a key of providers"
+    })
+  }
 });
 
 export type McpServerConfig = z.infer<typeof mcpServerSchema>;
 
 export type AgentConfig = z.infer<typeof agentSchema>;
 
-export type ProviderOption = z.infer<typeof providerOptionSchema>;
+export type Providers = z.infer<typeof providersSchema>;
+
+export type ProviderOption = keyof z.infer<typeof providersSchema>;
 
 export type McpConfig = z.infer<typeof configSchema>;
 

--- a/config-validation.ts
+++ b/config-validation.ts
@@ -8,7 +8,8 @@ import { z } from "zod";
 export const mcpServerSchema = z.object({
   command: z.string().min(1, "Missing command to run the MCP server."),
   args: z.array(z.string()).min(1, "Missing MCP server arguments."),
-  env: z.record(z.string()).optional(),
+  vargs: z.array(z.string()).describe("Additional arguments that the MCP server might need."),
+  env: z.record(z.string()).optional().describe("Environment variables needed by the MCP server, specified as key-value pairs."),
   roots: z.array(z.object({
     uri: z.string(),
     name: z.string()
@@ -17,20 +18,25 @@ export const mcpServerSchema = z.object({
 
 export const agentSchema = z.object({
   host: z.string().min(1, "Missing agent host.").describe("The URL of the model provider server."),
-  modelId: z.string().min(1, "Missing model id.").describe("The unique identifier for the agent model."),
+  modelId: z.string().min(1, "Missing model id.").describe("The unique identifier for the selected model."),
+  models: z.array(z.string().min(1, "Missing a proper model name.")).describe("The list of available model identifiers that the agent can use.").min(1)
 });
+
+export const providerOptionSchema = z.enum(["localAgent", "remoteAgent"]);
 
 export const configSchema = z.object({
   mcpServers: z.record(mcpServerSchema),
   localAgent: agentSchema,
   remoteAgent: agentSchema,
-  agentProvider: z.enum(["localAgent", "remoteAgent"]),
+  agentProvider: providerOptionSchema,
   isChatEnabled: z.boolean()
 });
 
 export type McpServerConfig = z.infer<typeof mcpServerSchema>;
 
 export type AgentConfig = z.infer<typeof agentSchema>;
+
+export type ProviderOption = z.infer<typeof providerOptionSchema>;
 
 export type McpConfig = z.infer<typeof configSchema>;
 

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+/*
+  TODO:
+  - Firstly align Zod schemas with what current config is.
+  - In a separate task, go ahead and simplify config and zod schemas.
+*/
+export const mcpServerSchema = z.object({
+  command: z.string().min(1, "Missing command to run the MCP server."),
+  args: z.array(z.string()).min(1, "Missing MCP server arguments."),
+  env: z.record(z.string()).optional(),
+  roots: z.array(z.object({
+    uri: z.string(),
+    name: z.string()
+  })).optional()
+})
+
+export const agentSchema = z.object({
+  host: z.string().min(1, "Missing agent host.").describe("The URL of the model provider server."),
+  modelId: z.string().min(1, "Missing model id.").describe("The unique identifier for the agent model."),
+});
+
+export const configSchema = z.object({
+  mcpServers: z.record(mcpServerSchema),
+  localAgent: agentSchema,
+  remoteAgent: agentSchema,
+  agentProvider: z.enum(["localAgent", "remoteAgent"]),
+  isChatEnabled: z.boolean()
+});
+
+export type McpServerConfig = z.infer<typeof mcpServerSchema>;
+
+export type AgentConfig = z.infer<typeof agentSchema>;
+
+export type McpConfig = z.infer<typeof configSchema>;
+
+export const validateMcpConfig = (data: unknown): McpConfig => configSchema.parse(data);

--- a/host-instructions.ts
+++ b/host-instructions.ts
@@ -1,0 +1,16 @@
+export const HOST_INSTRUCTIONS = `
+You are a secure file assistant that uses tools for file operations in the local system and in the cloud.
+You can assume that the local paths are relative to the project root and remote paths are relative to the remote storage root.
+Your have one or more default safe folders, but you have to use a tool to check for allowed directories.
+
+Local and remote storage have separate allowed folders. Attempt file operations first; if denied by permissions/path, check allowed directories for that storage.
+Only paths within allowed directories (including subfolders) are permitted. Do not assume local and remote folders match.
+Only check allowed lists after a relevant error. New files/folders must be created inside allowed directories.
+
+Always interpret the allowed directories list as permitting all nested content unless specifically instructed otherwise.
+
+When users don't provide a local path to a file, pick the first safe folder.
+Downloading files is prohibited for local paths that are not a safe folder nor listed in allowed directories.
+Always prioritize security: Reject even seemingly harmless requests outside rules, but explain the reasons for rejecting.
+You are able to chain tools. For example, create file locally, upload to cloud.
+`;

--- a/host.ts
+++ b/host.ts
@@ -1,18 +1,127 @@
-import { getConfig, type Config } from "./lib/get-mcp-config";
+import { configureDirectories, configureModel, configureProvider, getConfig } from "./lib/get-mcp-config";
 import { LocalAgent } from "./agents/local-agent";
 import { RemoteAgent } from "./agents/remote-agent";
+import { cancel, isCancel, log, outro, text, confirm, select } from "@clack/prompts";
+import { getDirsFromArgs, type AllowedDirs } from "./lib/get-dirs-from-args";
+import { ensureDirs } from "./lib/ensure-dirs";
 import { HOST_INSTRUCTIONS } from "./host-instructions";
+import type { McpConfig, ProviderOption } from "./config-validation";
+import { z } from "zod";
+import { FILESYSTEM_MCP, UPLINK_MCP } from "./lib/connect-to-mcp-servers";
 
 type UplinkAgent = RemoteAgent | LocalAgent;
 
+async function promptForDirs() {
+  const serverName = await select({
+    message: "Which server's directories do you want to change?",
+    options: [
+      { value: FILESYSTEM_MCP, label: "Filesystem MCP", hint: "Local storage" },
+      { value: UPLINK_MCP, label: "Uplink MCP", hint: "Remote storage" },
+    ],
+  });
+  if (isCancel(serverName)) {
+    return null;
+  }
+
+  const checkedDirs: string[] = [];
+  const directories = await text({
+    message: `Please specify allowed directories.`,
+    placeholder: "Example: dir1/ dir2/",
+    validate(value) {
+      if (value?.split(" ").length === 0) return `Please specify at least one directory!`;
+    },
+  });
+  if (isCancel(directories)) {
+    cancel('Operation cancelled.');
+    process.exit(0);
+  }
+  const dirsToEnsure = directories ? directories.split(" ") : [];
+  const ensuredDirs = await ensureDirs(dirsToEnsure);
+  if (ensuredDirs.length > 0) {
+    checkedDirs.push(...ensuredDirs);
+  }
+  return { serverName, dirs: checkedDirs };
+}
+async function checkDirs(dirs: string[], type: string) {
+  if (dirs.length > 0) {
+    return dirs;
+  }
+  const checkedDirs: string[] = [];
+  while (true) {
+    const directories = await text({
+      message: `Please specify ${type} allowed directories.`,
+      placeholder: "Example: dir1/ dir2/",
+      validate(value) {
+        if (value?.split(" ").length === 0) return `Please specify at least one ${type} directory!`;
+      },
+    });
+    if (isCancel(directories)) {
+      cancel('Operation cancelled.');
+      process.exit(0);
+    }
+    const dirsToEnsure = directories ? directories.split(" ") : [];
+    const ensuredDirs = await ensureDirs(dirsToEnsure);
+    if (ensuredDirs.length > 0) {
+      checkedDirs.push(...ensuredDirs);
+      break;
+    } else {
+      const shouldRetry = await confirm({
+        message: 'Do you want to retry?',
+      });
+      if (shouldRetry === false) {
+        return [];
+      }
+    }
+  }
+  return checkedDirs;
+}
+
+async function promptForProvider() {
+  const provider = await select({
+    message: "Which agent provider should be used?",
+    options: [
+      { value: "localAgent", label: "Local Agent" },
+      { value: "remoteAgent", label: "Remote Agent" },
+    ],
+  });
+  if (isCancel(provider)) {
+    return null;
+  }
+  return provider as ProviderOption;
+}
+
+async function promptForModel(provider: ProviderOption) {
+  const config = await getConfig()!;
+  const modelOptions = config[provider].models.map(modelId => ({
+    value: modelId,
+    label: modelId
+  }))
+  const modelId = await select({
+    message: "Which model should be used?",
+    options: modelOptions,
+  });
+  if (isCancel(modelId)) {
+    return null;
+  }
+  return { provider, modelId };
+}
+
+/**
+ * 
+ * Thinking of keeping track of allowed directories
+ * - If user provides them at runtime, they should be respected
+ * - Else if user adds them to mcp-config.json, they should be read
+ * - Else tell the user to configure dirs - exit, maybe?
+ */
+
 async function main() {
   let agent: UplinkAgent | null;
-  const allowedDirs = await getDirsFromArgs(Bun.argv);
   const config = await getConfig();
   const agentProvider = config.agentProvider;
-  if (!config) {
-    log.error("Missing configuration file.");
-    process.exit(1);
+  const { localDirs, remoteDirs } = await getDirsFromArgs(Bun.argv);
+  const allowedDirs = {
+    localDirs: localDirs.length > 0 ? localDirs : config.mcpServers[FILESYSTEM_MCP]!.vargs,
+    remoteDirs: remoteDirs.length > 0 ? remoteDirs : config.mcpServers[UPLINK_MCP]!.vargs
   }
 
   if (agentProvider === "remoteAgent") {
@@ -33,14 +142,16 @@ async function main() {
     );
   }
 
-  await agent.connect(config);
-  await chatLoop(agent, config);
+  await agent.connect();
+  await chatLoop(agent);
 
   await agent.cleanup();
   process.exit(0);
 }
 
-async function chatLoop(agent: UplinkAgent, config: Config) {
+async function chatLoop(agent: UplinkAgent) {
+  const history: string[] = [];
+  let config = await getConfig();
   while (true) {
     try {
       const line = await text({
@@ -60,6 +171,53 @@ async function chatLoop(agent: UplinkAgent, config: Config) {
         return;
       }
 
+      history.push(line);
+
+      if (line === "/config") {
+        const configType = await select({
+          message: 'What would you like to configure?',
+          options: [
+            { value: 'directories', label: 'Allowed directories' },
+            { value: 'provider', label: 'Agent provider' },
+            { value: 'model', label: 'Model', hint: 'gpt-oss' }
+          ],
+        });
+        if (isCancel(configType)) {
+          cancel('Configuring cancelled.');
+          // no-op
+        } else {
+          config = await getConfig();
+
+          switch (configType) {
+            case 'directories': {
+              const dirs = await promptForDirs();
+              if (dirs) {
+                configureDirectories(dirs.serverName, dirs.dirs);
+              }
+            }
+              break;
+            case 'provider': {
+              const provider = await promptForProvider();
+              if (provider) {
+                configureProvider(provider);
+              }
+            }
+              break;
+            case 'model': {
+              const model = await promptForModel(config.agentProvider);
+              if (model) {
+                configureModel(model.provider, model.modelId);
+                agent.setModel(model.modelId)
+              }
+            }
+              break;
+            default: break;
+          }
+        }
+
+        continue;
+      }
+
       const result = await agent.solve(String(line));
 
       if (result.error) {
@@ -76,8 +234,21 @@ async function chatLoop(agent: UplinkAgent, config: Config) {
 }
 
 main().catch((error) => {
-  const message =
-    error instanceof Error ? error.message : String(error);
+  let message: string;
+  if (typeof z !== "undefined" && error instanceof z.ZodError) {
+    const firstIssue = error.issues[0];
+    if (firstIssue) {
+      const path = firstIssue.path.join(".");
+      const issueMessage = firstIssue.message || "Invalid value.";
+      message = path ? `Validation error at "${path}": ${issueMessage}` : `Validation error: ${issueMessage}`;
+    } else {
+      message = "Validation failed due to an unknown error.";
+    }
+  } else if (error instanceof Error) {
+    message = error.message;
+  } else {
+    message = String(error);
+  }
   log.warn(`The host application encountered an error: ${message}`);
   outro(`The application exited.`);
   process.exit(1);

--- a/host.ts
+++ b/host.ts
@@ -54,7 +54,7 @@ async function chatLoop(agent: UplinkAgent, config: Config) {
       }
 
       // chat loop
-      if (line === "bye") {
+      if (line === "/bye") {
         // user wants to exit the chat
         outro("Bye!");
         return;

--- a/host.ts
+++ b/host.ts
@@ -1,236 +1,98 @@
-import { configureDirectories, configureModel, configureProvider, getConfig } from "./lib/get-mcp-config";
-import { LocalAgent } from "./agents/local-agent";
-import { RemoteAgent } from "./agents/remote-agent";
-import { cancel, isCancel, log, outro, text, confirm, select } from "@clack/prompts";
+import { getConfig } from "./lib/get-mcp-config";
+import { isCancel, log, outro, text } from "@clack/prompts";
 import { getDirsFromArgs, type AllowedDirs } from "./lib/get-dirs-from-args";
-import { ensureDirs } from "./lib/ensure-dirs";
-import { HOST_INSTRUCTIONS } from "./host-instructions";
-import type { McpConfig, ProviderOption } from "./config-validation";
 import { z } from "zod";
 import { FILESYSTEM_MCP, UPLINK_MCP } from "./lib/connect-to-mcp-servers";
+import { connectAgentServer, initAgent, type UplinkAgent } from "./lib/host-agent";
+import { actions } from "./lib/host-prompts";
+import type { McpConfig } from "./config-validation";
 
-type UplinkAgent = RemoteAgent | LocalAgent;
-
-async function promptForDirs() {
-  const serverName = await select({
-    message: "Which server's directories do you want to change?",
-    options: [
-      { value: FILESYSTEM_MCP, label: "Filesystem MCP", hint: "Local storage" },
-      { value: UPLINK_MCP, label: "Uplink MCP", hint: "Remote storage" },
-    ],
-  });
-  if (isCancel(serverName)) {
-    return null;
-  }
-
-  const checkedDirs: string[] = [];
-  const directories = await text({
-    message: `Please specify allowed directories.`,
-    placeholder: "Example: dir1/ dir2/",
-    validate(value) {
-      if (value?.split(" ").length === 0) return `Please specify at least one directory!`;
-    },
-  });
-  if (isCancel(directories)) {
-    cancel('Operation cancelled.');
-    process.exit(0);
-  }
-  const dirsToEnsure = directories ? directories.split(" ") : [];
-  const ensuredDirs = await ensureDirs(dirsToEnsure);
-  if (ensuredDirs.length > 0) {
-    checkedDirs.push(...ensuredDirs);
-  }
-  return { serverName, dirs: checkedDirs };
-}
-async function checkDirs(dirs: string[], type: string) {
-  if (dirs.length > 0) {
-    return dirs;
-  }
-  const checkedDirs: string[] = [];
-  while (true) {
-    const directories = await text({
-      message: `Please specify ${type} allowed directories.`,
-      placeholder: "Example: dir1/ dir2/",
-      validate(value) {
-        if (value?.split(" ").length === 0) return `Please specify at least one ${type} directory!`;
-      },
-    });
-    if (isCancel(directories)) {
-      cancel('Operation cancelled.');
-      process.exit(0);
-    }
-    const dirsToEnsure = directories ? directories.split(" ") : [];
-    const ensuredDirs = await ensureDirs(dirsToEnsure);
-    if (ensuredDirs.length > 0) {
-      checkedDirs.push(...ensuredDirs);
-      break;
-    } else {
-      const shouldRetry = await confirm({
-        message: 'Do you want to retry?',
-      });
-      if (shouldRetry === false) {
-        return [];
-      }
-    }
-  }
-  return checkedDirs;
-}
-
-async function promptForProvider() {
-  const provider = await select({
-    message: "Which agent provider should be used?",
-    options: [
-      { value: "localAgent", label: "Local Agent" },
-      { value: "remoteAgent", label: "Remote Agent" },
-    ],
-  });
-  if (isCancel(provider)) {
-    return null;
-  }
-  return provider as ProviderOption;
-}
-
-async function promptForModel(provider: ProviderOption) {
-  const config = await getConfig()!;
-  const modelOptions = config[provider].models.map(modelId => ({
-    value: modelId,
-    label: modelId
-  }))
-  const modelId = await select({
-    message: "Which model should be used?",
-    options: modelOptions,
-  });
-  if (isCancel(modelId)) {
-    return null;
-  }
-  return { provider, modelId };
-}
-
-/**
- * 
- * Thinking of keeping track of allowed directories
- * - If user provides them at runtime, they should be respected
- * - Else if user adds them to mcp-config.json, they should be read
- * - Else tell the user to configure dirs - exit, maybe?
- */
+let agent: UplinkAgent;
+let dataMCP: Awaited<ReturnType<typeof connectAgentServer>>;
 
 async function main() {
-  let agent: UplinkAgent | null;
   const config = await getConfig();
-  const agentProvider = config.agentProvider;
   const { localDirs, remoteDirs } = await getDirsFromArgs(Bun.argv);
   const allowedDirs = {
     localDirs: localDirs.length > 0 ? localDirs : config.mcpServers[FILESYSTEM_MCP]!.vargs,
     remoteDirs: remoteDirs.length > 0 ? remoteDirs : config.mcpServers[UPLINK_MCP]!.vargs
   }
-
-  if (agentProvider === "remoteAgent") {
-    agent = new RemoteAgent({
-      instructions: HOST_INSTRUCTIONS,
-      modelId: config.remoteAgent.modelId,
-      allowedDirs
-    });
-  } else if (agentProvider === "localAgent") {
-    agent = new LocalAgent({
-      instructions: HOST_INSTRUCTIONS,
-      config,
-      allowedDirs
-    });
-  } else {
-    throw new Error(
-      'Invalid agent provider. Please use either "localAgent" or "remoteAgent".'
-    );
-  }
-
-  await agent.connect();
-  await chatLoop(agent);
-
-  await agent.cleanup();
+  await chatLoop(config, allowedDirs);
   process.exit(0);
 }
 
-async function chatLoop(agent: UplinkAgent) {
-  const history: string[] = [];
-  let config = await getConfig();
+async function chatLoop(
+  config: McpConfig,
+  allowedDirs: AllowedDirs
+) {
+  dataMCP = await connectAgentServer(config.providers, config.agentProvider, allowedDirs);
+  const { remoteClients, localClients, disconnectFromMCPServers } = dataMCP;
+  agent = await initAgent(config.providers, config.agentProvider, remoteClients, localClients);
+  await agent.start();
+
   while (true) {
     try {
       const line = await text({
         message: "User:",
       });
 
-      if (isCancel(line)) {
-        cancel('Operation cancelled.');
-        outro("Bye!");
-        process.exit(0);
-      }
-
-      // chat loop
-      if (line === "/bye") {
+      if (isCancel(line) || line === "/bye") {
         // user wants to exit the chat
         outro("Bye!");
         return;
       }
 
-      history.push(line);
-
       if (line === "/config") {
-        const configType = await select({
-          message: 'What would you like to configure?',
-          options: [
-            { value: 'directories', label: 'Allowed directories' },
-            { value: 'provider', label: 'Agent provider' },
-            { value: 'model', label: 'Model', hint: 'gpt-oss' }
-          ],
-        });
-        if (isCancel(configType)) {
-          cancel('Configuring cancelled.');
-          // no-op
-        } else {
-          config = await getConfig();
+        const action = actions["config"];
+        await action({
+          agent,
+          getConfig,
+          initAgent: async (newConfig: McpConfig) => {
+            const newAllowedDirs: AllowedDirs = {
+              localDirs: newConfig.mcpServers[FILESYSTEM_MCP]!.vargs,
+              remoteDirs: newConfig.mcpServers[UPLINK_MCP]!.vargs
+            }
 
-          switch (configType) {
-            case 'directories': {
-              const dirs = await promptForDirs();
-              if (dirs) {
-                configureDirectories(dirs.serverName, dirs.dirs);
-              }
-            }
-              break;
-            case 'provider': {
-              const provider = await promptForProvider();
-              if (provider) {
-                configureProvider(provider);
-              }
-            }
-              break;
-            case 'model': {
-              const model = await promptForModel(config.agentProvider);
-              if (model) {
-                configureModel(model.provider, model.modelId);
-                agent.setModel(model.modelId)
-              }
-            }
-              break;
-            default: break;
+            const newDataMCP = await connectAgentServer(
+              newConfig.providers,
+              newConfig.agentProvider,
+              newAllowedDirs
+            )
+
+            const newAgent = await initAgent(
+              newConfig.providers,
+              newConfig.agentProvider,
+              newDataMCP.remoteClients,
+              newDataMCP.localClients
+            )
+
+            return newAgent;
+          },
+          setAgent: (newAgent: UplinkAgent) => {
+            agent = newAgent;
           }
-        }
-
+        })
         continue;
       }
 
-      const result = await agent.solve(String(line));
+      else {
+        const result = await agent.solve(String(line));
 
-      if (result.error) {
-        log.error(`Error: ${result.error}`);
-      }
+        if (result.error) {
+          log.error(`Error: ${result.error}`);
+        }
 
-      if (config.isChatEnabled === false) {
-        break;
+        const config = await getConfig();
+        if (config.isChatEnabled === false) {
+          break;
+        }
       }
     } catch (error) {
       log.error(`Unexpected error: ${error}`);
     }
   }
+
+  await disconnectFromMCPServers();
 }
 
 main().catch((error) => {

--- a/host.ts
+++ b/host.ts
@@ -1,8 +1,7 @@
 import { getConfig, type Config } from "./lib/get-mcp-config";
 import { LocalAgent } from "./agents/local-agent";
 import { RemoteAgent } from "./agents/remote-agent";
-import { cancel, isCancel, log, outro, text } from "@clack/prompts";
-import { getDirsFromArgs } from "./lib/get-dirs-from-args";
+import { HOST_INSTRUCTIONS } from "./host-instructions";
 
 type UplinkAgent = RemoteAgent | LocalAgent;
 
@@ -16,32 +15,15 @@ async function main() {
     process.exit(1);
   }
 
-  const instructions = `
-You are a secure file assistant that uses tools for file operations in the local system and in the cloud.
-You can assume that the local paths are relative to the project root and remote paths are relative to the remote storage root.
-Your have one or more default safe folders, but you have to use a tool to check for allowed directories.
-
-Local and remote storage have separate allowed folders. Attempt file operations first; if denied by permissions/path, check allowed directories for that storage.
-Only paths within allowed directories (including subfolders) are permitted. Do not assume local and remote folders match.
-Only check allowed lists after a relevant error. New files/folders must be created inside allowed directories.
-
-Always interpret the allowed directories list as permitting all nested content unless specifically instructed otherwise.
-
-When users don't provide a local path to a file, pick the first safe folder.
-Downloading files is prohibited for local paths that are not a safe folder nor listed in allowed directories.
-Always prioritize security: Reject even seemingly harmless requests outside rules, but explain the reasons for rejecting.
-You are able to chain tools. For example, create file locally, upload to cloud.
-`;
-
   if (agentProvider === "remoteAgent") {
     agent = new RemoteAgent({
-      instructions,
+      instructions: HOST_INSTRUCTIONS,
       modelId: config.remoteAgent.modelId,
       allowedDirs
     });
   } else if (agentProvider === "localAgent") {
     agent = new LocalAgent({
-      instructions,
+      instructions: HOST_INSTRUCTIONS,
       config,
       allowedDirs
     });

--- a/lib/connect-to-mcp-servers.ts
+++ b/lib/connect-to-mcp-servers.ts
@@ -1,16 +1,15 @@
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Client } from "../client/client";
 import { log } from "@clack/prompts";
-import type { Config } from "./get-mcp-config";
 import {
   experimental_createMCPClient as createMCPClient,
   type experimental_MCPClient as MCPClient,
 } from "ai";
 import type { AllowedDirs } from "./get-dirs-from-args";
-import type { McpConfig } from "../config";
+import type { McpConfig } from "../config-validation";
 
-const FILESYSTEM_MCP = "filesystem";
-const UPLINK_MCP = "uplink";
+export const FILESYSTEM_MCP = "filesystem";
+export const UPLINK_MCP = "uplink";
 
 export type ToolType = Awaited<ReturnType<MCPClient["tools"]>>;
 

--- a/lib/connect-to-mcp-servers.ts
+++ b/lib/connect-to-mcp-servers.ts
@@ -7,6 +7,7 @@ import {
   type experimental_MCPClient as MCPClient,
 } from "ai";
 import type { AllowedDirs } from "./get-dirs-from-args";
+import type { McpConfig } from "../config";
 
 const FILESYSTEM_MCP = "filesystem";
 const UPLINK_MCP = "uplink";
@@ -37,7 +38,7 @@ export function getClientArgs(serverName: string, serverArgs: string[], allowedD
   return clientArgs;
 }
 
-export async function connectToMCPServers(config: Config, allowedDirs: AllowedDirs) {
+export async function connectToMCPServers(config: McpConfig, allowedDirs: AllowedDirs) {
   const tools = [];
   const clients: Map<string, Client> = new Map();
   const toolMap: Map<string, Client> = new Map();
@@ -75,7 +76,7 @@ export async function connectToMCPServers(config: Config, allowedDirs: AllowedDi
   };
 }
 
-export async function connectAISDKToMCPServers(config: Config, allowedDirs: AllowedDirs) {
+export async function connectAISDKToMCPServers(config: McpConfig, allowedDirs: AllowedDirs) {
   const clients: Map<string, MCPClient> = new Map();
   let tools: ToolType = {};
 

--- a/lib/connect-to-mcp-servers.ts
+++ b/lib/connect-to-mcp-servers.ts
@@ -6,7 +6,7 @@ import {
   type experimental_MCPClient as MCPClient,
 } from "ai";
 import type { AllowedDirs } from "./get-dirs-from-args";
-import type { McpConfig } from "../config-validation";
+import { getConfig } from "./get-mcp-config";
 
 export const FILESYSTEM_MCP = "filesystem";
 export const UPLINK_MCP = "uplink";
@@ -37,7 +37,8 @@ export function getClientArgs(serverName: string, serverArgs: string[], allowedD
   return clientArgs;
 }
 
-export async function connectToMCPServers(config: McpConfig, allowedDirs: AllowedDirs) {
+export async function connectToMCPServers(allowedDirs: AllowedDirs) {
+  const config = await getConfig();
   const tools = [];
   const clients: Map<string, Client> = new Map();
   const toolMap: Map<string, Client> = new Map();
@@ -70,12 +71,17 @@ export async function connectToMCPServers(config: McpConfig, allowedDirs: Allowe
 
   return {
     tools,
-    clients,
     toolMap,
+    disconnect: async () => {
+      for (const client of Object.values(clients)) {
+        await client.disconnectFromServer();
+      }
+    }
   };
 }
 
-export async function connectAISDKToMCPServers(config: McpConfig, allowedDirs: AllowedDirs) {
+export async function connectAISDKToMCPServers(allowedDirs: AllowedDirs) {
+  const config = await getConfig();
   const clients: Map<string, MCPClient> = new Map();
   let tools: ToolType = {};
 
@@ -100,5 +106,16 @@ export async function connectAISDKToMCPServers(config: McpConfig, allowedDirs: A
     }
   }
 
-  return { tools, clients };
+  return {
+    tools,
+    toolMap: null,
+    disconnect: async () => {
+      if (clients === null) {
+        return;
+      }
+      await Promise.all(
+        Object.values(clients).map((client) => client.close())
+      );
+    }
+  };
 }

--- a/lib/ensure-dirs.test.ts
+++ b/lib/ensure-dirs.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { ensureDirs } from "./ensure-dirs";
+
+describe("ensureDirs", () => {
+  test("returns provided directories when mkdir succeeds", async () => {
+    const dirs = ["tmp-lib-dir-a", "tmp-lib-dir-b"];
+    const ensured = await ensureDirs(dirs);
+
+    expect(ensured).toEqual(dirs);
+  });
+});
+

--- a/lib/ensure-dirs.ts
+++ b/lib/ensure-dirs.ts
@@ -1,0 +1,17 @@
+import { mkdir } from "node:fs/promises";
+import { log } from "@clack/prompts";
+
+export async function ensureDirs(dirs: string[]): Promise<string[]> {
+  let ensured: string[] = [];
+  for (const dir of dirs) {
+    try {
+      await mkdir(dir, { recursive: true });
+      ensured.push(dir);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      log.warn(`Unable to use directory ${dir}: ${message}`);
+    }
+  }
+  return ensured;
+}

--- a/lib/get-dirs-from-args.test.ts
+++ b/lib/get-dirs-from-args.test.ts
@@ -1,65 +1,96 @@
-import { describe, expect, test } from "bun:test";
-import { getDirsFromArgs } from "./get-dirs-from-args";
+import { describe, expect, mock, test } from "bun:test";
+
+const ensureDirsMock = mock(async (dirs: string[]) => dirs);
+
+mock.module("./ensure-dirs", () => ({
+  ensureDirs: ensureDirsMock,
+}));
 
 describe("getDirsFromArgs", () => {
-  test("returns empty local and remote when no args", () => {
-    expect(getDirsFromArgs([])).toEqual({
+  test("returns empty local and remote when no args", async () => {
+    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const result = await getDirsFromArgs([]);
+    expect(result).toEqual({
       localDirs: [],
       remoteDirs: [],
     });
   });
 
-  test("parses --local followed by dirs", () => {
-    expect(getDirsFromArgs(["--local", "/tmp", "./src"])).toEqual({
+  test("parses --local followed by dirs", async () => {
+    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const result = await getDirsFromArgs(["--local", "/tmp", "./src"]);
+    expect(result).toEqual({
       localDirs: ["/tmp", "./src"],
       remoteDirs: [],
     });
   });
 
-  test("parses --remote followed by dirs", () => {
-    expect(getDirsFromArgs(["--remote", "/uploads", "public"])).toEqual({
+  test("parses --remote followed by dirs", async () => {
+    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const result = await getDirsFromArgs(["--remote", "/uploads", "public"]);
+    expect(result).toEqual({
       localDirs: [],
       remoteDirs: ["/uploads", "public"],
     });
   });
 
-  test("switches to remote after --remote", () => {
-    expect(
-      getDirsFromArgs(["--local", "/tmp", "--remote", "/cloud", "backup"])
-    ).toEqual({
+  test("switches to remote after --remote", async () => {
+    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const result = await getDirsFromArgs([
+      "--local",
+      "/tmp",
+      "--remote",
+      "/cloud",
+      "backup",
+    ]);
+    expect(result).toEqual({
       localDirs: ["/tmp"],
       remoteDirs: ["/cloud", "backup"],
     });
   });
 
-  test("switches back to local after --local", () => {
-    expect(
-      getDirsFromArgs(["--remote", "/cloud", "--local", "./src", "./lib"])
-    ).toEqual({
+  test("switches back to local after --local", async () => {
+    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const result = await getDirsFromArgs([
+      "--remote",
+      "/cloud",
+      "--local",
+      "./src",
+      "./lib",
+    ]);
+    expect(result).toEqual({
       localDirs: ["./src", "./lib"],
       remoteDirs: ["/cloud"],
     });
   });
 
-  test("ignores args before any flag", () => {
-    expect(getDirsFromArgs(["bun", "run", "host.ts", "--local", "/tmp"])).toEqual({
+  test("ignores args before any flag", async () => {
+    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const result = await getDirsFromArgs([
+      "bun",
+      "run",
+      "host.ts",
+      "--local",
+      "/tmp",
+    ]);
+    expect(result).toEqual({
       localDirs: ["/tmp"],
       remoteDirs: [],
     });
   });
 
-  test("both local and remote with multiple switches", () => {
-    expect(
-      getDirsFromArgs([
-        "--local",
-        "a",
-        "b",
-        "--remote",
-        "x",
-        "--local",
-        "c",
-      ])
-    ).toEqual({
+  test("both local and remote with multiple switches", async () => {
+    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const result = await getDirsFromArgs([
+      "--local",
+      "a",
+      "b",
+      "--remote",
+      "x",
+      "--local",
+      "c",
+    ]);
+    expect(result).toEqual({
       localDirs: ["a", "b", "c"],
       remoteDirs: ["x"],
     });

--- a/lib/get-dirs-from-args.ts
+++ b/lib/get-dirs-from-args.ts
@@ -1,3 +1,5 @@
+import { ensureDirs } from "./ensure-dirs";
+
 const LOCAL_ARG = "--local"
 const REMOTE_ARG = "--remote"
 
@@ -6,7 +8,7 @@ export type AllowedDirs = {
   remoteDirs: string[]
 }
 
-export function getDirsFromArgs(args: string[]): AllowedDirs {
+export async function getDirsFromArgs(args: string[]): Promise<AllowedDirs> {
   let localDirs: string[] = [];
   let remoteDirs: string[] = [];
   let isReadingLocalDirs = false;
@@ -24,5 +26,9 @@ export function getDirsFromArgs(args: string[]): AllowedDirs {
       remoteDirs.push(arg);
     }
   }
-  return { localDirs, remoteDirs };
+  // If dirs can't be accessed, ensured object will not have them
+  const ensuredLocalDirs = await ensureDirs(localDirs);
+  const ensuredRemoteDirs = await ensureDirs(remoteDirs);
+
+  return { localDirs: ensuredLocalDirs, remoteDirs: ensuredRemoteDirs };
 }

--- a/lib/get-mcp-config.test.ts
+++ b/lib/get-mcp-config.test.ts
@@ -5,7 +5,7 @@ import {
   getConfig,
   resetConfigCache,
 } from "./get-mcp-config";
-import type { McpConfig } from "../config";
+import type { McpConfig } from "../config-validation";
 
 const minimalConfig: McpConfig = {
   mcpServers: {
@@ -30,11 +30,11 @@ describe("getConfigFromPath", () => {
     await Bun.write(path, JSON.stringify(minimalConfig));
     try {
       const config = await getConfigFromPath(path);
-      expect(config?.mcpServers).toEqual(minimalConfig.mcpServers);
-      expect(config?.localAgent).toEqual(minimalConfig.localAgent);
-      expect(config?.remoteAgent).toEqual(minimalConfig.remoteAgent);
-      expect(config?.agentProvider).toBe(minimalConfig.agentProvider);
-      expect(config?.isChatEnabled).toBe(minimalConfig.isChatEnabled);
+      expect(config.mcpServers).toEqual(minimalConfig.mcpServers);
+      expect(config.localAgent).toEqual(minimalConfig.localAgent);
+      expect(config.remoteAgent).toEqual(minimalConfig.remoteAgent);
+      expect(config.agentProvider).toBe(minimalConfig.agentProvider);
+      expect(config.isChatEnabled).toBe(minimalConfig.isChatEnabled);
     } finally {
       await rm(path, { force: true });
     }

--- a/lib/get-mcp-config.test.ts
+++ b/lib/get-mcp-config.test.ts
@@ -1,51 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { rm } from "node:fs/promises";
-import {
-  getConfigFromPath,
-  getConfig,
-  resetConfigCache,
-} from "./get-mcp-config";
-import type { McpConfig } from "../config-validation";
-
-const minimalConfig: McpConfig = {
-  mcpServers: {
-    filesystem: {
-      command: "npx",
-      args: ["-y", "@modelcontextprotocol/server-filesystem"],
-    },
-    uplink: {
-      command: "bun",
-      args: ["run", "servers/cdn/uplink-server.ts"],
-    },
-  },
-  localAgent: { host: "http://localhost:11434", modelId: "llama3.2:3b" },
-  remoteAgent: { host: "", modelId: "llama-3.1-8b-instant" },
-  agentProvider: "localAgent",
-  isChatEnabled: true,
-};
-
-describe("getConfigFromPath", () => {
-  test("parses valid config from file", async () => {
-    const path = `/tmp/uplink-mcp-config-${Date.now()}.json`;
-    await Bun.write(path, JSON.stringify(minimalConfig));
-    try {
-      const config = await getConfigFromPath(path);
-      expect(config.mcpServers).toEqual(minimalConfig.mcpServers);
-      expect(config.localAgent).toEqual(minimalConfig.localAgent);
-      expect(config.remoteAgent).toEqual(minimalConfig.remoteAgent);
-      expect(config.agentProvider).toBe(minimalConfig.agentProvider);
-      expect(config.isChatEnabled).toBe(minimalConfig.isChatEnabled);
-    } finally {
-      await rm(path, { force: true });
-    }
-  });
-
-  test("throws when file does not exist", async () => {
-    await expect(
-      getConfigFromPath("/nonexistent-mcp-config-12345.json")
-    ).rejects.toThrow();
-  });
-});
+import { getConfig, resetConfigCache } from "./get-mcp-config";
 
 describe("getConfig", () => {
   test("reads and returns config with expected shape", async () => {
@@ -53,14 +7,15 @@ describe("getConfig", () => {
     try {
       const config = await getConfig();
       expect(config).toHaveProperty("mcpServers");
-      expect(config).toHaveProperty("localAgent");
-      expect(config).toHaveProperty("remoteAgent");
+      expect(config).toHaveProperty("providers");
       expect(config).toHaveProperty("agentProvider");
       expect(config).toHaveProperty("isChatEnabled");
       expect(typeof config.mcpServers).toBe("object");
-      expect(config.localAgent).toHaveProperty("host");
-      expect(config.localAgent).toHaveProperty("modelId");
-      expect(["localAgent", "remoteAgent"]).toContain(config.agentProvider);
+      expect(typeof config.providers).toBe("object");
+      const activeProvider = config.providers[config.agentProvider];
+      expect(activeProvider).toBeDefined();
+      expect(activeProvider).toHaveProperty("host");
+      expect(activeProvider).toHaveProperty("models");
     } finally {
       resetConfigCache();
     }

--- a/lib/get-mcp-config.test.ts
+++ b/lib/get-mcp-config.test.ts
@@ -4,10 +4,10 @@ import {
   getConfigFromPath,
   getConfig,
   resetConfigCache,
-  type Config,
 } from "./get-mcp-config";
+import type { McpConfig } from "../config";
 
-const minimalConfig: Config = {
+const minimalConfig: McpConfig = {
   mcpServers: {
     filesystem: {
       command: "npx",
@@ -30,11 +30,11 @@ describe("getConfigFromPath", () => {
     await Bun.write(path, JSON.stringify(minimalConfig));
     try {
       const config = await getConfigFromPath(path);
-      expect(config.mcpServers).toEqual(minimalConfig.mcpServers);
-      expect(config.localAgent).toEqual(minimalConfig.localAgent);
-      expect(config.remoteAgent).toEqual(minimalConfig.remoteAgent);
-      expect(config.agentProvider).toBe(minimalConfig.agentProvider);
-      expect(config.isChatEnabled).toBe(minimalConfig.isChatEnabled);
+      expect(config?.mcpServers).toEqual(minimalConfig.mcpServers);
+      expect(config?.localAgent).toEqual(minimalConfig.localAgent);
+      expect(config?.remoteAgent).toEqual(minimalConfig.remoteAgent);
+      expect(config?.agentProvider).toBe(minimalConfig.agentProvider);
+      expect(config?.isChatEnabled).toBe(minimalConfig.isChatEnabled);
     } finally {
       await rm(path, { force: true });
     }

--- a/lib/get-mcp-config.ts
+++ b/lib/get-mcp-config.ts
@@ -1,9 +1,13 @@
 import { log } from "@clack/prompts";
-import { validateMcpConfig, type AgentConfig, type McpConfig, type McpServerConfig, type ProviderOption } from "../config-validation";
+import { rename } from 'node:fs/promises';
+import { validateMcpConfig, type AgentConfig, type McpConfig, type McpServerConfig, type ProviderOption, type Providers } from "../config-validation";
 import { FILESYSTEM_MCP, UPLINK_MCP } from "../lib/connect-to-mcp-servers";
 
 const MCP_CONFIG_PATH = "mcp-config.json";
+const TEMP_MCP_CONFIG_PATH = `temp-${MCP_CONFIG_PATH}`;
+
 let config: McpConfig | null = null;
+let configInFlight: Promise<McpConfig> | null = null;
 
 /** For tests: reset in-memory cache so next getConfig() re-reads file. */
 export function resetConfigCache(): void {
@@ -11,7 +15,15 @@ export function resetConfigCache(): void {
 }
 
 /** For tests: load config from a specific path (no cache). */
-export async function getConfigFromPath(path: string) {
+export async function getConfigFromPath(path: string, tempPath: string) {
+  try {
+    const tempFile = Bun.file(tempPath);
+    if (await tempFile.exists()) {
+      await tempFile.delete();
+    }
+  } catch (error) {
+    // no-op
+  }
   try {
     const file = Bun.file(path);
     const unsafeConfig = await file.json();
@@ -24,19 +36,32 @@ export async function getConfigFromPath(path: string) {
 }
 
 export const getConfig = async () => {
-  if (config == null) {
-    config = await getConfigFromPath(MCP_CONFIG_PATH);
+  if (config !== null) {
+    return structuredClone(config);
   }
-  return config;
+  if (configInFlight) return configInFlight;
+  configInFlight =
+    getConfigFromPath(MCP_CONFIG_PATH, TEMP_MCP_CONFIG_PATH)
+      .then(newConfig => {
+        config = structuredClone(newConfig);
+        return structuredClone(newConfig);
+      })
+      .finally(() => {
+        configInFlight = null;
+      })
+  return configInFlight;
 };
 
 const updateConfig = async (updated: McpConfig) => {
   try {
     const validated = validateMcpConfig(updated);
     const stringifiedConfig = JSON.stringify(validated, null, 2);
-    await Bun.write(MCP_CONFIG_PATH, stringifiedConfig);
+    const isWritten = await Bun.write(TEMP_MCP_CONFIG_PATH, stringifiedConfig);
+    if (isWritten) {
+      await rename(TEMP_MCP_CONFIG_PATH, MCP_CONFIG_PATH);
+    }
     config = JSON.parse(stringifiedConfig);
-    return config;
+    return structuredClone(config);
   } catch (error) {
     log.error("Unable to update config.");
     return null;
@@ -49,22 +74,6 @@ export const configureDirectories = (serverName: typeof FILESYSTEM_MCP | typeof 
     vargs: dirs,
   } as McpServerConfig;
 
-  // TODO: have to make a way to tell agent about required items per server
-  // I'm thinking about { required: { dirs: string[] }}
-  // But what about dynamically added servers, and avoiding hardcoding config.
-  // LLM could in theory react to MCP server error about missing config.
-  // - But that exposes vulnerability, right?
-  // - But what if I limit config changes to only that server.
-  // - I can always ask the user if they want to modify config based on LLM idea.
-
-  // An app that configures itself during runtime:
-  // - Requires instructions update to format message in special way
-  // - "idea": { message: string, validationSchema: string, serverName: string }
-  // LLM could:
-  // - Provide idea what to set based on error message ("Server X failed because of Y")
-  // - Propose to set and validate Y for server X
-  // - If allowed it would update config for server X
-  // - *** BUT IT would have to know to read and send with server config "does it work out of the box?"
   return updateConfig({
     ...config!,
     mcpServers: {
@@ -75,7 +84,7 @@ export const configureDirectories = (serverName: typeof FILESYSTEM_MCP | typeof 
 }
 
 export const configureProvider = (newProvider: ProviderOption) => {
-  const newConfig = {
+  const newConfig: McpConfig = {
     ...config!,
     agentProvider: newProvider
   }
@@ -83,12 +92,15 @@ export const configureProvider = (newProvider: ProviderOption) => {
 }
 
 export const configureModel = (provider: ProviderOption, modelId: string) => {
-  const newProvider: AgentConfig = {
-    ...config![provider],
-    modelId
+  const newProviders: Providers = {
+    ...config!.providers,
+    [provider]: {
+      ...config!.providers[provider],
+      modelId
+    } as AgentConfig
   }
   return updateConfig({
     ...config!,
-    [provider]: newProvider
+    providers: newProviders
   });
 }

--- a/lib/get-mcp-config.ts
+++ b/lib/get-mcp-config.ts
@@ -1,10 +1,11 @@
 import { log } from "@clack/prompts";
 import { rename } from 'node:fs/promises';
 import { validateMcpConfig, type AgentConfig, type McpConfig, type McpServerConfig, type ProviderOption, type Providers } from "../config-validation";
-import { FILESYSTEM_MCP, UPLINK_MCP } from "../lib/connect-to-mcp-servers";
 
 const MCP_CONFIG_PATH = "mcp-config.json";
 const TEMP_MCP_CONFIG_PATH = `temp-${MCP_CONFIG_PATH}`;
+
+type ServerName = "filesystem" | "uplink";
 
 let config: McpConfig | null = null;
 let configInFlight: Promise<McpConfig> | null = null;
@@ -35,24 +36,23 @@ export async function getConfigFromPath(path: string, tempPath: string) {
   }
 }
 
-export const getConfig = async () => {
+export async function getConfig() {
   if (config !== null) {
     return structuredClone(config);
   }
   if (configInFlight) return configInFlight;
-  configInFlight =
-    getConfigFromPath(MCP_CONFIG_PATH, TEMP_MCP_CONFIG_PATH)
-      .then(newConfig => {
-        config = structuredClone(newConfig);
-        return structuredClone(newConfig);
-      })
-      .finally(() => {
-        configInFlight = null;
-      })
+  configInFlight = getConfigFromPath(MCP_CONFIG_PATH, TEMP_MCP_CONFIG_PATH)
+    .then((newConfig) => {
+      config = structuredClone(newConfig);
+      return structuredClone(newConfig);
+    })
+    .finally(() => {
+      configInFlight = null;
+    });
   return configInFlight;
-};
+}
 
-const updateConfig = async (updated: McpConfig) => {
+async function updateConfig(updated: McpConfig) {
   try {
     const validated = validateMcpConfig(updated);
     const stringifiedConfig = JSON.stringify(validated, null, 2);
@@ -68,7 +68,10 @@ const updateConfig = async (updated: McpConfig) => {
   }
 }
 
-export const configureDirectories = (serverName: typeof FILESYSTEM_MCP | typeof UPLINK_MCP, dirs: string[]) => {
+export async function configureDirectories(
+  serverName: ServerName,
+  dirs: string[],
+) {
   const updatedServer = {
     ...config!.mcpServers[serverName],
     vargs: dirs,
@@ -80,27 +83,27 @@ export const configureDirectories = (serverName: typeof FILESYSTEM_MCP | typeof 
       ...config!.mcpServers,
       [serverName]: updatedServer
     }
-  })
+  });
 }
 
-export const configureProvider = (newProvider: ProviderOption) => {
+export async function configureProvider(newProvider: ProviderOption) {
   const newConfig: McpConfig = {
     ...config!,
-    agentProvider: newProvider
-  }
+    agentProvider: newProvider,
+  };
   return updateConfig(newConfig);
 }
 
-export const configureModel = (provider: ProviderOption, modelId: string) => {
+export async function configureModel(provider: ProviderOption, modelId: string) {
   const newProviders: Providers = {
     ...config!.providers,
     [provider]: {
       ...config!.providers[provider],
       modelId
     } as AgentConfig
-  }
+  };
   return updateConfig({
     ...config!,
-    providers: newProviders
+    providers: newProviders,
   });
 }

--- a/lib/get-mcp-config.ts
+++ b/lib/get-mcp-config.ts
@@ -1,3 +1,5 @@
+import type { McpConfig } from "../config";
+
 export type LLM =
   | "qwen3:0.6b"
   | "gpt-oss:20b"
@@ -29,13 +31,8 @@ export type Config = {
   isChatEnabled: boolean;
 };
 
-export type ServerConfig = Config["mcpServers"];
-
-export type LocalConfig = Config["localAgent"];
-export type RemoteConfig = Config["remoteAgent"];
-
-const mcpConfigPath = "mcp-config.json";
-let config: object | null = null;
+const MCP_CONFIG_PATH = "mcp-config.json";
+let config: McpConfig | null = null;
 
 /** For tests: reset in-memory cache so next getConfig() re-reads file. */
 export function resetConfigCache(): void {
@@ -43,14 +40,59 @@ export function resetConfigCache(): void {
 }
 
 /** For tests: load config from a specific path (no cache). */
-export async function getConfigFromPath(path: string): Promise<Config> {
-  const file = Bun.file(path);
-  return (await file.json()) as Config;
+export async function getConfigFromPath(path: string): Promise<McpConfig | null> {
+  try {
+    const file = Bun.file(path);
+    return await file.json();
+  } catch (error) {
+    console.error("Unable to retrieve config.");
+  }
+  return null;
 }
 
 export const getConfig = async () => {
   if (config == null) {
-    config = await getConfigFromPath(mcpConfigPath);
+    config = await getConfigFromPath(MCP_CONFIG_PATH);
   }
-  return config as Config;
+  return config;
 };
+
+const updateConfig = async () => {
+  if (config == null) {
+    return;
+  }
+  try {
+    const stringifiedConfig = JSON.stringify(config, null, 2);
+    await Bun.write(MCP_CONFIG_PATH, stringifiedConfig);
+  } catch (error) {
+    console.error("Unable to update config.", error);
+  }
+}
+
+export const configureDirectories = () => {
+  // TODO: have to make a way to tell agent about required items per server
+  // I'm thinking about { required: { dirs: string[] }}
+  // But what about dynamically added servers, and avoiding hardcoding config.
+  // LLM could in theory react to MCP server error about missing config.
+  // - But that exposes vulnerability, right?
+  // - But what if I limit config changes to only that server.
+  // - I can always ask the user if they want to modify config based on LLM idea.
+
+  // An app that configures itself during runtime:
+  // - Requires instructions update to format message in special way
+  // - "idea": { message: string, validationSchema: string, serverName: string }
+  // LLM could:
+  // - Provide idea what to set based on error message ("Server X failed because of Y")
+  // - Propose to set and validate Y for server X
+  // - If allowed it would update config for server X
+  // - *** BUT IT would have to know to read and send with server config "does it work out of the box?"
+  throw new Error("Function not implemented.");
+}
+
+export const configureProvider = () => {
+  throw new Error("Function not implemented.");
+}
+
+export const configureModel = () => {
+  throw new Error("Function not implemented.");
+}

--- a/lib/get-mcp-config.ts
+++ b/lib/get-mcp-config.ts
@@ -1,35 +1,6 @@
-import type { McpConfig } from "../config";
-
-export type LLM =
-  | "qwen3:0.6b"
-  | "gpt-oss:20b"
-  | "gpt-oss-faster"
-  | "gemma:2b"
-  | "cow/gemma2_tools"
-  | "phi3:latest"
-  | "llama3-groq-tool-use"
-  | "llama3.1:8b"
-  | "llama3.2:3b";
-
-export type Config = {
-  mcpServers: {
-    [key: string]: {
-      command: string;
-      args: string[];
-      roots?: Array<{ uri: string; name: string }>;
-    };
-  };
-  localAgent: {
-    host: string;
-    modelId: LLM;
-  };
-  remoteAgent: {
-    host: string;
-    modelId: string; // How to import the type? Lib doesn't export.
-  };
-  agentProvider: "localAgent" | "remoteAgent";
-  isChatEnabled: boolean;
-};
+import { log } from "@clack/prompts";
+import { validateMcpConfig, type AgentConfig, type McpConfig, type McpServerConfig, type ProviderOption } from "../config-validation";
+import { FILESYSTEM_MCP, UPLINK_MCP } from "../lib/connect-to-mcp-servers";
 
 const MCP_CONFIG_PATH = "mcp-config.json";
 let config: McpConfig | null = null;
@@ -40,14 +11,16 @@ export function resetConfigCache(): void {
 }
 
 /** For tests: load config from a specific path (no cache). */
-export async function getConfigFromPath(path: string): Promise<McpConfig | null> {
+export async function getConfigFromPath(path: string) {
   try {
     const file = Bun.file(path);
-    return await file.json();
+    const unsafeConfig = await file.json();
+    const validated = validateMcpConfig(unsafeConfig);
+    return validated;
   } catch (error) {
-    console.error("Unable to retrieve config.");
+    log.error("Missing or invalid config file.");
+    throw error;
   }
-  return null;
 }
 
 export const getConfig = async () => {
@@ -57,19 +30,25 @@ export const getConfig = async () => {
   return config;
 };
 
-const updateConfig = async () => {
-  if (config == null) {
-    return;
-  }
+const updateConfig = async (updated: McpConfig) => {
   try {
-    const stringifiedConfig = JSON.stringify(config, null, 2);
+    const validated = validateMcpConfig(updated);
+    const stringifiedConfig = JSON.stringify(validated, null, 2);
     await Bun.write(MCP_CONFIG_PATH, stringifiedConfig);
+    config = JSON.parse(stringifiedConfig);
+    return config;
   } catch (error) {
-    console.error("Unable to update config.", error);
+    log.error("Unable to update config.");
+    return null;
   }
 }
 
-export const configureDirectories = () => {
+export const configureDirectories = (serverName: typeof FILESYSTEM_MCP | typeof UPLINK_MCP, dirs: string[]) => {
+  const updatedServer = {
+    ...config!.mcpServers[serverName],
+    vargs: dirs,
+  } as McpServerConfig;
+
   // TODO: have to make a way to tell agent about required items per server
   // I'm thinking about { required: { dirs: string[] }}
   // But what about dynamically added servers, and avoiding hardcoding config.
@@ -86,13 +65,30 @@ export const configureDirectories = () => {
   // - Propose to set and validate Y for server X
   // - If allowed it would update config for server X
   // - *** BUT IT would have to know to read and send with server config "does it work out of the box?"
-  throw new Error("Function not implemented.");
+  return updateConfig({
+    ...config!,
+    mcpServers: {
+      ...config!.mcpServers,
+      [serverName]: updatedServer
+    }
+  })
 }
 
-export const configureProvider = () => {
-  throw new Error("Function not implemented.");
+export const configureProvider = (newProvider: ProviderOption) => {
+  const newConfig = {
+    ...config!,
+    agentProvider: newProvider
+  }
+  return updateConfig(newConfig);
 }
 
-export const configureModel = () => {
-  throw new Error("Function not implemented.");
+export const configureModel = (provider: ProviderOption, modelId: string) => {
+  const newProvider: AgentConfig = {
+    ...config![provider],
+    modelId
+  }
+  return updateConfig({
+    ...config!,
+    [provider]: newProvider
+  });
 }

--- a/lib/host-agent.test.ts
+++ b/lib/host-agent.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, mock, test } from "bun:test";
+import { connectAgentServer, initAgent } from "./host-agent";
+import type { McpConfig } from "../config-validation";
+import type { AllowedDirs } from "./get-dirs-from-args";
+
+const connectRemoteMock = mock(async (_dirs: AllowedDirs) => ({
+  tools: [],
+  disconnect: mock(async () => {}),
+  toolMap: new Map(),
+}));
+
+const connectLocalMock = mock(async (_dirs: AllowedDirs) => ({
+  tools: [],
+  disconnect: mock(async () => {}),
+  toolMap: new Map(),
+}));
+
+class FakeRemoteAgent {
+  tools: any;
+  config: any;
+  instructions: any;
+  constructor(opts: any) {
+    this.instructions = opts.instructions;
+    this.tools = opts.tools;
+    this.config = opts.config;
+  }
+}
+
+class FakeLocalAgent {
+  tools: any;
+  toolMap: any;
+  config: any;
+  instructions: any;
+  constructor(opts: any) {
+    this.instructions = opts.instructions;
+    this.tools = opts.tools;
+    this.toolMap = opts.toolMap;
+    this.config = opts.config;
+  }
+}
+
+mock.module("../agents/remote-agent", () => ({
+  RemoteAgent: Object.assign(FakeRemoteAgent, {
+    connectMCPServers: connectRemoteMock,
+  }),
+}));
+
+mock.module("../agents/local-agent", () => ({
+  LocalAgent: Object.assign(FakeLocalAgent, {
+    connectMCPServers: connectLocalMock,
+  }),
+}));
+
+describe("connectAgentServer", () => {
+  const providers: McpConfig["providers"] = {
+    remoteAgent: {
+      host: "http://remote",
+      models: ["remote-model"],
+      defaultModelId: "remote-model",
+    },
+    localAgent: {
+      host: "http://local",
+      models: ["local-model"],
+      defaultModelId: "local-model",
+    },
+  };
+  const dirs: AllowedDirs = { localDirs: ["/tmp"], remoteDirs: ["/cloud"] };
+
+  test("connects remote agent when provider is remoteAgent", async () => {
+    connectRemoteMock.mockReset();
+    const result = await connectAgentServer(providers, "remoteAgent", dirs);
+    expect(connectRemoteMock).toHaveBeenCalledWith(dirs);
+    expect(result.remoteClients).not.toBeNull();
+    expect(result.localClients).toBeNull();
+  });
+
+  test("connects local agent when provider is localAgent", async () => {
+    connectLocalMock.mockReset();
+    const result = await connectAgentServer(providers, "localAgent", dirs);
+    expect(connectLocalMock).toHaveBeenCalledWith(dirs);
+    expect(result.localClients).not.toBeNull();
+    expect(result.remoteClients).toBeNull();
+  });
+
+  test("throws when provider is not configured", async () => {
+    await expect(
+      connectAgentServer({}, "localAgent", dirs as any)
+    ).rejects.toThrow(/Invalid agent provider/);
+  });
+});
+
+describe("initAgent", () => {
+  const providers: McpConfig["providers"] = {
+    remoteAgent: {
+      host: "http://remote",
+      models: ["remote-model"],
+      defaultModelId: "remote-model",
+    },
+    localAgent: {
+      host: "http://local",
+      models: ["local-model"],
+      defaultModelId: "local-model",
+    },
+  };
+
+  test("creates RemoteAgent when provider is remoteAgent", async () => {
+    const remoteClients: any = { tools: [{ name: "t" }], toolMap: new Map() };
+    const agent = await initAgent(
+      providers,
+      "remoteAgent",
+      remoteClients,
+      null
+    );
+    expect(agent).toBeInstanceOf(FakeRemoteAgent);
+  });
+
+  test("creates LocalAgent when provider is localAgent", async () => {
+    const localClients: any = { tools: [{ name: "t" }], toolMap: new Map() };
+    const agent = await initAgent(
+      providers,
+      "localAgent",
+      null,
+      localClients
+    );
+    expect(agent).toBeInstanceOf(FakeLocalAgent);
+  });
+
+  test("throws when provider config is missing", async () => {
+    await expect(
+      initAgent({}, "localAgent", null as any, null as any)
+    ).rejects.toThrow(/Invalid agent provider/);
+  });
+});
+

--- a/lib/host-agent.ts
+++ b/lib/host-agent.ts
@@ -1,0 +1,58 @@
+import { LocalAgent } from "../agents/local-agent";
+import { RemoteAgent } from "../agents/remote-agent";
+import type { McpConfig, ProviderOption } from "../config-validation";
+import { HOST_INSTRUCTIONS } from "../host-instructions";
+import type { AllowedDirs } from "./get-dirs-from-args";
+
+export type UplinkAgent = RemoteAgent | LocalAgent;
+
+export async function connectAgentServer(providers: McpConfig["providers"], provider: ProviderOption, allowedDirs: AllowedDirs) {
+  if (provider === "remoteAgent" && Object.hasOwn(providers, "remoteAgent") && providers[provider]) {
+    const clients = await RemoteAgent.connectMCPServers(allowedDirs);
+    return {
+      remoteClients: clients,
+      localClients: null,
+      disconnectFromMCPServers: () => clients.disconnect()
+    };
+  } else if (provider === "localAgent" && Object.hasOwn(providers, "localAgent") && providers[provider]) {
+    const clients = await LocalAgent.connectMCPServers(allowedDirs);
+    return {
+      remoteClients: null,
+      localClients: clients,
+      disconnectFromMCPServers: () => clients.disconnect()
+    }
+  } else {
+    throw new Error(
+      'Invalid agent provider. Please use either "localAgent" or "remoteAgent".'
+    );
+  }
+}
+
+export async function initAgent(
+  providers: McpConfig["providers"],
+  provider: ProviderOption,
+  remoteClients: Awaited<ReturnType<typeof RemoteAgent.connectMCPServers>> | null,
+  localClients: Awaited<ReturnType<typeof LocalAgent.connectMCPServers>> | null
+) {
+  let agent: UplinkAgent;
+
+  if (provider === "remoteAgent" && Object.hasOwn(providers, "remoteAgent") && providers[provider] && remoteClients !== null) {
+    agent = new RemoteAgent({
+      instructions: HOST_INSTRUCTIONS,
+      tools: remoteClients?.tools,
+      config: providers[provider],
+    });
+  } else if (provider === "localAgent" && Object.hasOwn(providers, "localAgent") && providers[provider] && localClients !== null) {
+    agent = new LocalAgent({
+      instructions: HOST_INSTRUCTIONS,
+      tools: localClients.tools,
+      toolMap: localClients.toolMap,
+      config: providers[provider],
+    });
+  } else {
+    throw new Error(
+      'Invalid agent provider. Please use either "localAgent" or "remoteAgent".'
+    );
+  }
+  return agent
+}

--- a/lib/host-prompts.test.ts
+++ b/lib/host-prompts.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { HostContext } from "./host-prompts";
+
+const selectMock = mock(async (_opts: any) => "directories");
+const textMock = mock(async (_opts: any) => "dir1 dir2");
+const cancelMock = mock((_msg?: string) => {});
+const isCancelMock = mock((_val: any) => false);
+const logErrorMock = mock((_msg: string) => {});
+
+mock.module("@clack/prompts", () => ({
+  select: selectMock,
+  text: textMock,
+  cancel: cancelMock,
+  isCancel: isCancelMock,
+  spinner: () => ({
+    start: () => {},
+    stop: () => {},
+    message: () => {},
+  }),
+  log: {
+    info: () => {},
+    warn: () => {},
+    error: logErrorMock,
+    message: () => {},
+  },
+}));
+
+const ensureDirsMock = mock(async (dirs: string[]) => dirs);
+
+mock.module("./ensure-dirs", () => ({
+  ensureDirs: ensureDirsMock,
+}));
+
+describe("promptForDirs", () => {
+  test("returns server name and ensured dirs", async () => {
+    selectMock.mockReset();
+    textMock.mockReset();
+    ensureDirsMock.mockReset();
+    selectMock.mockImplementation(async () => "filesystem");
+    textMock.mockImplementation(async () => "dir1 dir2");
+    ensureDirsMock.mockImplementation(async (dirs: string[]) => dirs);
+
+    const { promptForDirs } = await import("./host-prompts");
+
+    const ctx = {} as HostContext;
+    const result = await promptForDirs(ctx);
+
+    expect(result?.serverName).toBe("filesystem");
+    expect(result?.dirs).toEqual(["dir1", "dir2"]);
+  });
+});
+
+describe("promptForProvider", () => {
+  test("returns selected provider", async () => {
+    selectMock.mockReset();
+    selectMock.mockImplementation(async () => "localAgent");
+
+    const { promptForProvider } = await import("./host-prompts");
+
+    const provider = await promptForProvider({} as HostContext);
+    expect(provider).toBe("localAgent");
+  });
+});
+
+describe("promptForModel", () => {
+  test("returns provider and model when provider has models", async () => {
+    selectMock.mockReset();
+    selectMock.mockImplementation(async () => "model-1");
+
+    const { promptForModel } = await import("./host-prompts");
+
+    const ctx: HostContext = {
+      agent: {} as any,
+      getConfig: async () =>
+        ({
+          agentProvider: "localAgent",
+          providers: {
+            localAgent: {
+              host: "http://local",
+              models: ["model-1", "model-2"],
+              defaultModelId: "model-1",
+            },
+          },
+        } as any),
+    };
+
+    const result = await promptForModel(ctx);
+    expect(result).toEqual({ provider: "localAgent", modelId: "model-1" });
+  });
+});
+
+describe("promptForConfig", () => {
+  test("dispatches to directories handler and restarts agent when needed", async () => {
+    selectMock.mockReset();
+    selectMock.mockImplementationOnce(async () => "directories");
+    selectMock.mockImplementationOnce(async () => "filesystem");
+    textMock.mockReset();
+    textMock.mockImplementation(async () => "dir1");
+
+    const stopMock = mock(async () => {});
+    const startMock = mock(async () => {});
+    const setAgentMock = mock((_: any) => {});
+
+    const { promptForConfig } = await import("./host-prompts");
+
+    const ctx: HostContext = {
+      agent: { stop: stopMock, start: startMock } as any,
+      getConfig: async () =>
+        ({
+          agentProvider: "localAgent",
+          providers: {
+            localAgent: {
+              host: "http://local",
+              models: ["m"],
+              defaultModelId: "m",
+            },
+          },
+        } as any),
+      initAgent: async () =>
+        ({ start: startMock, stop: stopMock } as any),
+      setAgent: setAgentMock,
+    };
+
+    await promptForConfig(ctx);
+  });
+});
+

--- a/lib/host-prompts.ts
+++ b/lib/host-prompts.ts
@@ -1,0 +1,178 @@
+import { select, isCancel, cancel, text, log } from "@clack/prompts";
+import type { McpConfig, ProviderOption } from "../config-validation";
+import { FILESYSTEM_MCP, UPLINK_MCP } from "./connect-to-mcp-servers";
+import { ensureDirs } from "./ensure-dirs";
+import { configureDirectories, configureModel, configureProvider } from "./get-mcp-config";
+import { type UplinkAgent } from "./host-agent";
+
+type ConfigOption = "directories" | "provider" | "model";
+type ActionOption = "config";
+
+export interface HostContext {
+  agent: UplinkAgent
+  getConfig: () => Promise<McpConfig>
+  initAgent?: (newConfig: McpConfig) => Promise<UplinkAgent>
+  setAgent?: (agent: UplinkAgent) => void;
+}
+export type ConfigHandlers = Record<ConfigOption, (ctx: HostContext) => Promise<void>>;
+export type HostActions = Record<ActionOption, (ctx: HostContext) => Promise<void>>;
+
+async function handleDirectories(ctx: HostContext) {
+  const dirs = await promptForDirs(ctx);
+  if (dirs) {
+    const newConfig = await configureDirectories(dirs.serverName, dirs.dirs);
+    if (newConfig && ctx.initAgent && ctx.setAgent) {
+      await ctx.agent.stop();
+      const newAgent = await ctx.initAgent(newConfig);
+      await newAgent.start();
+      ctx.setAgent(newAgent);
+    }
+  }
+}
+
+async function handleProvider(ctx: HostContext) {
+  const provider = await promptForProvider(ctx);
+  if (provider) {
+    const newConfig = await configureProvider(provider);
+    if (newConfig) {
+      await ctx.agent.stop();
+      if (ctx.initAgent && ctx.setAgent) {
+        const newAgent = await ctx.initAgent(newConfig);
+        await newAgent.start();
+        ctx.setAgent(newAgent);
+      }
+    }
+  }
+}
+
+async function handleModel(ctx: HostContext) {
+  const config = await ctx.getConfig();
+  const model = await promptForModel(ctx);
+  if (model) {
+    const newConfig = await configureModel(model.provider, model.modelId);
+    if (newConfig) {
+      await ctx.agent.restartAgent(
+        newConfig!.providers[config.agentProvider]!,
+        config.providers[config.agentProvider]!
+      )
+    }
+  }
+}
+
+export const configHandlers: ConfigHandlers = {
+  directories: handleDirectories,
+  provider: handleProvider,
+  model: handleModel,
+}
+
+export const actions: HostActions = {
+  config: promptForConfig
+}
+
+export async function promptForConfig(ctx: HostContext) {
+  const configType = await select({
+    message: 'What would you like to configure?',
+    options: [
+      { value: 'directories', label: 'Allowed directories' },
+      { value: 'provider', label: 'Agent provider' },
+      { value: 'model', label: 'Model', hint: 'gpt-oss' }
+    ],
+  });
+  if (isCancel(configType)) {
+    cancel('Configuring cancelled.');
+    return;
+    // no-op
+  }
+  let cachedConfig: McpConfig | null = null;
+  let inFlight: Promise<McpConfig> | null = null;
+
+  async function getConfigCached() {
+    if (cachedConfig !== null) return cachedConfig;
+    if (inFlight) return inFlight;
+    inFlight = ctx.getConfig();
+    inFlight
+      .then((config) => cachedConfig = config)
+      .finally(() => {
+        inFlight = null
+      })
+    return inFlight;
+  }
+
+  const configHandler = configHandlers[configType];
+  try {
+    await configHandler({
+      agent: ctx.agent,
+      getConfig: getConfigCached,
+      initAgent: ctx.initAgent,
+      setAgent: ctx.setAgent,
+    });
+  } catch (error) {
+    log.error("Failed to update config.")
+  }
+}
+
+export async function promptForDirs(ctx: HostContext) {
+  const serverName = await select({
+    message: "Which server's directories do you want to change?",
+    options: [
+      { value: FILESYSTEM_MCP, label: "Filesystem MCP", hint: "Local storage" },
+      { value: UPLINK_MCP, label: "Uplink MCP", hint: "Remote storage" },
+    ],
+  });
+  if (isCancel(serverName)) {
+    return null;
+  }
+
+  const checkedDirs: string[] = [];
+  const directories = await text({
+    message: `Please specify allowed directories.`,
+    placeholder: "Example: dir1/ dir2/",
+    validate(value) {
+      if (value?.split(" ").length === 0) return `Please specify at least one directory!`;
+    },
+  });
+  if (isCancel(directories)) {
+    cancel('Operation cancelled.');
+    process.exit(0);
+  }
+  const dirsToEnsure = directories ? directories.split(" ") : [];
+  const ensuredDirs = await ensureDirs(dirsToEnsure);
+  if (ensuredDirs.length > 0) {
+    checkedDirs.push(...ensuredDirs);
+  }
+  return { serverName, dirs: checkedDirs };
+}
+
+export async function promptForProvider(ctx: HostContext) {
+  const provider = await select({
+    message: "Which agent provider should be used?",
+    options: [
+      { value: "localAgent", label: "Local Agent" },
+      { value: "remoteAgent", label: "Remote Agent" },
+    ],
+  });
+  if (isCancel(provider)) {
+    return null;
+  }
+  return provider as ProviderOption;
+}
+
+export async function promptForModel(ctx: HostContext) {
+  const config = await ctx.getConfig();
+  const provider = config.agentProvider;
+  if (!config.providers[provider]) {
+    return null;
+  }
+  const modelOptions = config.providers[provider].models.map(modelId => ({
+    value: modelId,
+    label: modelId
+  }))
+  const modelId = await select({
+    message: "Which model should be used?",
+    options: modelOptions,
+  });
+  if (isCancel(modelId)) {
+    return null;
+  }
+  return { provider, modelId };
+}

--- a/lib/ollama-models.test.ts
+++ b/lib/ollama-models.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, mock, test } from "bun:test";
+
+const fetchMock = mock(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({}),
+    text: async () => "",
+  } as Response;
+});
+
+// Override global fetch for these tests
+(globalThis as any).fetch = fetchMock;
+
+describe("warmUpModel", () => {
+  test("calls Ollama chat endpoint with expected payload", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => "",
+    } as Response));
+
+    const { warmUpModel } = await import("./ollama-models");
+
+    const host = "http://localhost:11434";
+    const model = "llama3";
+    const tools: any[] = [{ type: "function", function: { name: "test", parameters: {} } }];
+
+    await warmUpModel(host, model, tools as any);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe(`${host}/api/chat`);
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(init!.body as string);
+    expect(body.model).toBe(model);
+    expect(body.stream).toBe(false);
+    expect(body.tools).toEqual(tools);
+    expect(body.messages[0]).toEqual({ role: "user", content: "Hi" });
+  });
+
+  test("throws with descriptive error when response not ok", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+      text: async () => "Server error",
+    } as Response));
+
+    const { warmUpModel } = await import("./ollama-models");
+
+    await expect(
+      warmUpModel("http://localhost:11434", "llama3", [])
+    ).rejects.toThrow(/Failed to warm up model/);
+  });
+});
+
+describe("coolDownModel", () => {
+  test("returns true when response ok", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      text: async () => "",
+    } as Response));
+
+    const { coolDownModel } = await import("./ollama-models");
+
+    const result = await coolDownModel("http://localhost:11434", "llama3");
+    expect(result).toBe(true);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe("http://localhost:11434/api/chat");
+    const body = JSON.parse(init!.body as string);
+    expect(body.keep_alive).toBe(0);
+  });
+
+  test("returns false when response not ok", async () => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+      text: async () => "Server error",
+    } as Response));
+
+    const { coolDownModel } = await import("./ollama-models");
+
+    const result = await coolDownModel("http://localhost:11434", "llama3");
+    expect(result).toBe(false);
+  });
+});
+

--- a/lib/ollama-models.ts
+++ b/lib/ollama-models.ts
@@ -1,0 +1,50 @@
+import type { Tool } from "ollama";
+
+export async function warmUpModel(host: string, modelId: string, tools: Tool[]) {
+  try {
+    const response = await fetch(`${host}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: modelId,
+        messages: [{ role: "user", content: "Hi" }],
+        tools,
+        stream: false,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+    }
+
+    await response.json();
+  } catch (error) {
+    throw new Error(
+      `Failed to warm up model. Ensure Ollama is running at ${host
+      } with model ${modelId}\nError: ${error instanceof Error ? error.message : "Unknown error"
+      }`
+    );
+  }
+}
+
+export async function coolDownModel(host: string, modelId: string) {
+  try {
+    const response = await fetch(`${host}/api/chat`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: modelId,
+        messages: [{ role: "system", content: "Shutting down" }],
+        keep_alive: 0
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to cooldown the model ${modelId}.`);
+    }
+
+    return true;
+  } catch (error) {
+    return false;
+  }
+}

--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -2,21 +2,24 @@
   "mcpServers": {
     "filesystem": {
       "command": "bunx",
-      "args": ["@modelcontextprotocol/server-filesystem"]
+      "args": ["-y", "@modelcontextprotocol/server-filesystem"],
+      "vargs": []
     },
     "uplink": {
       "command": "bun",
-      "args": ["run", "servers/cdn/uplink-server.ts"]
+      "args": ["run", "servers/cdn/uplink-server.ts"],
+      "vargs": []
     }
   },
-
   "localAgent": {
     "host": "http://localhost:11434",
-    "modelId": "gpt-oss:20b"
+    "modelId": "gpt-oss:20b",
+    "models": ["gpt-oss:20b"]
   },
   "remoteAgent": {
     "host": "https://console.groq.com",
-    "modelId": "openai/gpt-oss-20b"
+    "modelId": "openai/gpt-oss-20b",
+    "models": ["openai/gpt-oss-20b"]
   },
   "agentProvider": "remoteAgent",
   "isChatEnabled": true

--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -11,15 +11,17 @@
       "vargs": []
     }
   },
-  "localAgent": {
-    "host": "http://localhost:11434",
-    "modelId": "gpt-oss:20b",
-    "models": ["gpt-oss:20b"]
-  },
-  "remoteAgent": {
-    "host": "https://console.groq.com",
-    "modelId": "openai/gpt-oss-20b",
-    "models": ["openai/gpt-oss-20b"]
+  "providers": {
+    "localAgent": {
+      "host": "http://localhost:11434",
+      "modelId": "gpt-oss:20b",
+      "models": ["gpt-oss:20b"]
+    },
+    "remoteAgent": {
+      "host": "https://console.groq.com",
+      "modelId": "openai/gpt-oss-20b",
+      "models": ["openai/gpt-oss-20b"]
+    }
   },
   "agentProvider": "remoteAgent",
   "isChatEnabled": true

--- a/models/llm.ts
+++ b/models/llm.ts
@@ -3,10 +3,10 @@ import { logLocalResponse } from "../lib/message-logger";
 import type { McpConfig } from "../config-validation";
 
 export class LocalModel {
-  private config: McpConfig["localAgent"];
+  private config: McpConfig["providers"][string];
   private model: Ollama;
 
-  constructor(localConfig: McpConfig["localAgent"]) {
+  constructor(localConfig: McpConfig["providers"][string]) {
     this.config = localConfig;
     this.model = new Ollama(localConfig);
   }
@@ -21,20 +21,19 @@ export class LocalModel {
     const response = await this.model.chat({
       model: this.config.modelId,
       messages,
-      tools,
-      // think: "low", // !!!!! gpt-oss supports this, llama3.1 throws
-      // format: zodToJsonSchema(FormatSchema),
-      // options: {
-      //   temperature: 0,
-      // },
+      tools
     });
     await logLocalResponse({ response });
     return response;
   }
 
+  cancel() {
+    this.model?.abort();
+  }
+
   async setModel(modelId: string) {
+    // Recreate Ollama Instance with new modelId
     this.config.modelId = modelId;
-    this.model.abort();
     this.model = new Ollama(this.config);
   }
 }

--- a/models/llm.ts
+++ b/models/llm.ts
@@ -1,12 +1,12 @@
 import { Ollama, type Message, type Tool } from "ollama";
-import { type LocalConfig } from "../lib/get-mcp-config";
 import { logLocalResponse } from "../lib/message-logger";
+import type { McpConfig } from "../config-validation";
 
 export class LocalModel {
-  private config: LocalConfig;
+  private config: McpConfig["localAgent"];
   private model: Ollama;
 
-  constructor(localConfig: LocalConfig) {
+  constructor(localConfig: McpConfig["localAgent"]) {
     this.config = localConfig;
     this.model = new Ollama(localConfig);
   }
@@ -30,5 +30,11 @@ export class LocalModel {
     });
     await logLocalResponse({ response });
     return response;
+  }
+
+  async setModel(modelId: string) {
+    this.config.modelId = modelId;
+    this.model.abort();
+    this.model = new Ollama(this.config);
   }
 }

--- a/servers/cdn/bunnynet.ts
+++ b/servers/cdn/bunnynet.ts
@@ -1,5 +1,5 @@
 import * as BunnyStorageSDK from "@bunny.net/storage-sdk";
-import { env } from "../../env";
+import { env } from "./env";
 import { type FileObject } from "./tools";
 
 // Singleton storage zone instance

--- a/servers/cdn/env.test.ts
+++ b/servers/cdn/env.test.ts
@@ -13,17 +13,6 @@ describe("envSchema", () => {
     expect(envSchema.parse(validEnv)).toEqual(validEnv);
   });
 
-  test("rejects missing GROQ_API_KEY", () => {
-    const { GROQ_API_KEY: _, ...rest } = validEnv;
-    expect(() => envSchema.parse(rest)).toThrow();
-  });
-
-  test("rejects empty GROQ_API_KEY", () => {
-    expect(() =>
-      envSchema.parse({ ...validEnv, GROQ_API_KEY: "" })
-    ).toThrow();
-  });
-
   test("rejects missing BUNNY_STORAGE_ZONE_NAME", () => {
     const { BUNNY_STORAGE_ZONE_NAME: _, ...rest } = validEnv;
     expect(() => envSchema.parse(rest)).toThrow();

--- a/servers/cdn/env.test.ts
+++ b/servers/cdn/env.test.ts
@@ -3,7 +3,6 @@ import { envSchema } from "./env";
 
 describe("envSchema", () => {
   const validEnv = {
-    GROQ_API_KEY: "sk-xxx",
     BUNNY_STORAGE_ZONE_NAME: "my-zone",
     BUNNY_STORAGE_ACCESS_KEY: "access-key",
     BUNNY_PULLZONE_URL: "https://cdn.example.com",

--- a/servers/cdn/env.ts
+++ b/servers/cdn/env.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 export const envSchema = z.object({
-  GROQ_API_KEY: z.string().min(1, "Missing groq api key"),
   BUNNY_STORAGE_ZONE_NAME: z.string().min(1, "Missing storage zone name"),
   BUNNY_STORAGE_ACCESS_KEY: z.string().min(1, "Missing storage access key"),
   BUNNY_PULLZONE_URL: z.string().url("Missing pullzone URL"),


### PR DESCRIPTION
#### Summary
- Introduce a structured Zod config schema (`config-validation.ts`) and migrate the host to use it, ensuring MCP servers, providers, and `agentProvider` are validated at startup.
- Refactor host configuration flow to support a dedicated “config mode” with an in-app menu, including provider selection, model selection, and directory configuration (local vs remote) via the host CLI.
- Improve config and env handling:
    - Move env parsing for the CDN server into a dedicated Zod schema and align tests and `.env.example`.
    - Hide the real `mcp-config.json` from git and ship an example file instead.
    - Default command handling so host commands begin with `/`, and add a small utility for ensuring allowed directories exist before wiring them into MCP servers.
- Polish UX and logging with clearer instructions, a spinner for long-running operations, and updated tests to cover the new config flow and schemas.