### PR TITLE
Add CLI oneshot prompt mode to host

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Uplink is a lightweight open-source tool that fuses local filesystem management 
 
 Runs entirely in the terminal: browse, organise, edit and create files, or upload them to a cloud provider while steering the workflow with natural-language instructions.
 
-By default the agentic loop stays open (`isChatEnabled` defaults to `true`): the AI keeps accepting new prompts until you type `bye`, chaining tool calls between questions. Set `isChatEnabled` to `false` for single-run mode, where the agent takes your prompt, calls MCP tools until it reaches a solution, responds, and exits.
+By default the agentic loop stays open: the AI keeps accepting new prompts until you type `/bye`, chaining tool calls between questions. Passing `--local` / `--remote` directory arguments only changes which folders the agent can touch—it still runs in interactive chat mode. For single-run mode, start the host with a one-off `--prompt` argument (for example `bun run host.ts --prompt "summarise README.md"`); the host will run the tools it needs, respond once, and exit.
 
 [CI](https://github.com/gsicvj/uplink/actions/workflows/ci.yml)
 [codecov](https://codecov.io/gh/gsicvj/uplink)
@@ -47,12 +47,12 @@ Assistant: You’re welcome! The file is now safely stored in the cloud.
     "filesystem": {
       "command": "bunx",
       "args": ["-y", "@modelcontextprotocol/server-filesystem"],
-      "vargs": []
+      "vargs": ["relative-to-project-root/", "/or/absolute/path"]
     },
     "uplink": {
       "command": "bun",
       "args": ["run", "servers/cdn/uplink-server.ts"],
-      "vargs": []
+      "vargs": ["/", "other/nested/paths/"]
     }
   },
   "providers": {
@@ -67,8 +67,7 @@ Assistant: You’re welcome! The file is now safely stored in the cloud.
       "models": ["openai/gpt-oss-20b"]
     }
   },
-  "agentProvider": "remoteAgent",
-  "isChatEnabled": true
+  "agentProvider": "remoteAgent"
 }
 ```
 
@@ -83,26 +82,26 @@ The `providers` map defines all available agents and their models. Set `agentPro
 
 ## TODO
 
-- Merge ollama and uplink docker stages into a single stage
-- Update UX with external CLI libraries (@clack/prompt and @chalk)
-- Use input arguments for run startup commands
-- Add .env.example to simplify setting environment variables
-- Fix new setup where ENOENT: no such file or directory, open 'logging/local.log'
-- Move allowed dirs from mcp-config to host app args
-- Enable tool toogle or multiple select for allowed/banned
-- Provide script argument for local/remote model
-- Implement in-app model selection
-- Implement in-app provider selection
-- Implement in-app allowed directories selection
-- Use MCP to handle roots change instead of restarting agent on dirs change
-- Add unit high and medium value tests
-- Simplify config and Zod schemas
-- Enter chat mode when no args are provided, remove isChatEnabled flag
-- Implement terminal history
-- Create a user flow, ask what would a user want, and refactor where valuable
-- Treat local agent as Ollama Custom Provider
-- Simplify agents by merging Local and Remote Agent
-- Train and use a smaller domain specific model
+- [ ] Merge ollama and uplink docker stages into a single stage
+- [x] Update UX with external CLI libraries (@clack/prompt and @chalk)
+- [x] Use input arguments for run startup commands
+- [x] Add .env.example to simplify setting environment variables
+- [x] Fix new setup where ENOENT: no such file or directory, open 'logging/local.log'
+- [x] Move allowed dirs from mcp-config to host app args
+- [x] Implement in-app model selection
+- [x] Implement in-app provider selection
+- [x] Implement in-app allowed directories selection
+- [x] Add unit high and medium value tests
+- [x] Simplify config and Zod schemas
+- [x] Enter chat mode when no --prompt arg is provided
+- [ ] Enable tool toogle or multiple select for allowed/banned
+- [ ] Use MCP to handle roots change instead of restarting agent on dirs change
+- [ ] Create a user flow, ask what would a user want, and refactor where valuable
+- [ ] Treat local agent as Ollama Custom Provider
+- [ ] Simplify agents by merging Local and Remote Agent
+- [ ] Implement terminal history
+- [ ] Provide script argument for local/remote model
+- [ ] Train and use a smaller domain specific model
 
 ## License
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -19,15 +19,16 @@
 
 6. **Configure `mcp-config.json`** to choose your LLM provider:
 
-   - Set `"agentProvider": "remoteAgent"` to use cloud LLMs (Groq by default; see step 7 for changing providers)
-   - Set `"agentProvider": "localAgent"` to use Ollama (requires step 8)
-   - Keep `"isChatEnabled": true` to allow the agent to respond conversationally and explain its actions
+   - Copy `mcp-config.example.json` to `mcp-config.json`.
+   - Under `"providers"`, set `remoteAgent.modelId` to a Groq model (for example `openai/gpt-oss-20b`) and `localAgent.modelId` to an installed Ollama model (for example `gpt-oss:20b`).
+   - Use the `"models"` arrays on each provider to list all available model IDs you want to select from in the app.
+   - Set `"agentProvider": "remoteAgent"` or `"localAgent"` to pick which provider is used by default; you can still switch provider and model from within the host.
 
 7. **(Optional) Pick a different remote LLM provider** if you already have access to one:
 
-   - Browse the [AI SDK provider catalog](https://ai-sdk.dev/providers/ai-sdk-providers/openai) to find a compatible provider and note the install instructions
-   - Update `agents/remote-agent.ts` so the `model` field uses that provider's SDK export instead of Groq (for example `openai(this.modelId)` after importing `{ openai } from "@ai-sdk/openai"`)
-   - Set `remoteAgent.modelId` in `mcp-config.json` to a model offered by that provider
+   - Browse the [AI SDK provider catalog](https://ai-sdk.dev/providers/ai-sdk-providers/openai) to find a compatible provider and note the install instructions.
+   - Update `agents/remote-agent.ts` so the `model` field uses that provider's SDK export instead of Groq (for example `openai(this.config.modelId)` after importing `{ openai } from "@ai-sdk/openai"`).
+   - Set `providers.remoteAgent.modelId` in `mcp-config.json` to a model offered by that provider.
 
 8. **(Optional) Install Ollama** to run local LLMs:
 
@@ -38,7 +39,13 @@
    ollama pull llama3.1:8b  # Pull this model (if limited with hardware)
    ```
 
-9. **Run the application** to start the agent: `bun run host.ts --local assets downloads --remote /`. Use `--local` for allowed filesystem directories and `--remote` for allowed uplink (CDN) directories.
+9. **Run the application** to start the agent:
+
+   ```bash
+   bun run host.ts --local assets downloads --remote /
+   ```
+
+   Use `--local` for allowed filesystem directories and `--remote` for allowed uplink (CDN) directories. If you also pass a `--prompt "your question"` argument, the host will run in single-run (oneshot) mode: it will answer once and then exit. Without `--prompt`, it stays in interactive chat mode until you type `/bye`.
 
 ## Troubleshooting
 

--- a/agents/local-agent.ts
+++ b/agents/local-agent.ts
@@ -6,7 +6,7 @@ import { logLocalResponse } from "../lib/message-logger";
 import { LocalModel } from "../models/llm";
 import type { Message, Tool, ToolCall, ChatResponse } from "ollama";
 import type { McpConfig } from "../config-validation";
-import type { AllowedDirs } from "../lib/get-dirs-from-args";
+import type { AllowedDirs } from "../lib/evaluate-args";
 import { connectToMCPServers } from "../lib/connect-to-mcp-servers";
 import { coolDownModel, warmUpModel } from "../lib/ollama-models";
 

--- a/agents/remote-agent.ts
+++ b/agents/remote-agent.ts
@@ -11,7 +11,7 @@ import type { SolveResult } from "./local-agent";
 import chalk from "chalk";
 import type { McpConfig } from "../config-validation";
 import { connectAISDKToMCPServers, type ToolType } from "../lib/connect-to-mcp-servers";
-import type { AllowedDirs } from "../lib/get-dirs-from-args";
+import type { AllowedDirs } from "../lib/evaluate-args";
 
 export class RemoteAgent {
   private agent: any | null = null;

--- a/config-validation.test.ts
+++ b/config-validation.test.ts
@@ -85,8 +85,7 @@ describe("configSchema / validateMcpConfig", () => {
         models: ["llama3"],
       },
     },
-    agentProvider: "localAgent",
-    isChatEnabled: true,
+    agentProvider: "localAgent"
   } as const;
 
   test("validateMcpConfig parses a valid config", () => {

--- a/config-validation.ts
+++ b/config-validation.ts
@@ -28,7 +28,6 @@ export const configSchema = z.object({
   mcpServers: z.record(mcpServerSchema),
   providers: providersSchema,
   agentProvider: z.string(),
-  isChatEnabled: z.boolean()
 }).superRefine((cfg, ctx) => {
   if (!(Object.hasOwn(cfg.providers, cfg.agentProvider))) {
     ctx.addIssue({

--- a/host.ts
+++ b/host.ts
@@ -1,6 +1,6 @@
 import { getConfig } from "./lib/get-mcp-config";
 import { isCancel, log, outro, text } from "@clack/prompts";
-import { getDirsFromArgs, type AllowedDirs } from "./lib/get-dirs-from-args";
+import { getDirsFromArgs, getPromptFromArgs, type AllowedDirs } from "./lib/evaluate-args";
 import { z } from "zod";
 import { FILESYSTEM_MCP, UPLINK_MCP } from "./lib/connect-to-mcp-servers";
 import { connectAgentServer, initAgent, type UplinkAgent } from "./lib/host-agent";
@@ -13,17 +13,19 @@ let dataMCP: Awaited<ReturnType<typeof connectAgentServer>>;
 async function main() {
   const config = await getConfig();
   const { localDirs, remoteDirs } = await getDirsFromArgs(Bun.argv);
+  const oneshotPrompt = await getPromptFromArgs(Bun.argv);
   const allowedDirs = {
     localDirs: localDirs.length > 0 ? localDirs : config.mcpServers[FILESYSTEM_MCP]!.vargs,
     remoteDirs: remoteDirs.length > 0 ? remoteDirs : config.mcpServers[UPLINK_MCP]!.vargs
   }
-  await chatLoop(config, allowedDirs);
+  await chatLoop(config, allowedDirs, oneshotPrompt);
   process.exit(0);
 }
 
 async function chatLoop(
   config: McpConfig,
-  allowedDirs: AllowedDirs
+  allowedDirs: AllowedDirs,
+  oneshotPrompt?: string
 ) {
   dataMCP = await connectAgentServer(config.providers, config.agentProvider, allowedDirs);
   const { remoteClients, localClients, disconnectFromMCPServers } = dataMCP;
@@ -32,9 +34,13 @@ async function chatLoop(
 
   while (true) {
     try {
-      const line = await text({
-        message: "User:",
-      });
+      let line: string | symbol | undefined = oneshotPrompt;
+
+      if (!line) {
+        line = await text({
+          message: "User:",
+        });
+      }
 
       if (isCancel(line) || line === "/bye") {
         // user wants to exit the chat
@@ -82,8 +88,8 @@ async function chatLoop(
           log.error(`Error: ${result.error}`);
         }
 
-        const config = await getConfig();
-        if (config.isChatEnabled === false) {
+        const hasOneshotPrompt = typeof oneshotPrompt === "string" && oneshotPrompt.length > 1;
+        if (hasOneshotPrompt) {
           break;
         }
       }

--- a/lib/connect-to-mcp-servers.test.ts
+++ b/lib/connect-to-mcp-servers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { getClientArgs } from "./connect-to-mcp-servers";
-import type { AllowedDirs } from "./get-dirs-from-args";
+import type { AllowedDirs } from "./evaluate-args";
 
 describe("getClientArgs", () => {
   const baseArgs = ["--some", "arg"];

--- a/lib/connect-to-mcp-servers.ts
+++ b/lib/connect-to-mcp-servers.ts
@@ -5,7 +5,7 @@ import {
   experimental_createMCPClient as createMCPClient,
   type experimental_MCPClient as MCPClient,
 } from "ai";
-import type { AllowedDirs } from "./get-dirs-from-args";
+import type { AllowedDirs } from "./evaluate-args";
 import { getConfig } from "./get-mcp-config";
 
 export const FILESYSTEM_MCP = "filesystem";

--- a/lib/evaluate-args.ts
+++ b/lib/evaluate-args.ts
@@ -2,6 +2,7 @@ import { ensureDirs } from "./ensure-dirs";
 
 const LOCAL_ARG = "--local"
 const REMOTE_ARG = "--remote"
+const PROMPT_ARG = "--prompt"
 
 export type AllowedDirs = {
   localDirs: string[],
@@ -31,4 +32,11 @@ export async function getDirsFromArgs(args: string[]): Promise<AllowedDirs> {
   const ensuredRemoteDirs = await ensureDirs(remoteDirs);
 
   return { localDirs: ensuredLocalDirs, remoteDirs: ensuredRemoteDirs };
+}
+
+export async function getPromptFromArgs(args: string[]): Promise<string | null> {
+  const promptArgIndex = args.indexOf(PROMPT_ARG);
+  if (promptArgIndex === -1) return null;
+  const text = args[promptArgIndex + 1];
+  return typeof text === "string" ? text : null;
 }

--- a/lib/get-dirs-from-args.test.ts
+++ b/lib/get-dirs-from-args.test.ts
@@ -8,7 +8,7 @@ mock.module("./ensure-dirs", () => ({
 
 describe("getDirsFromArgs", () => {
   test("returns empty local and remote when no args", async () => {
-    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const { getDirsFromArgs } = await import("./evaluate-args");
     const result = await getDirsFromArgs([]);
     expect(result).toEqual({
       localDirs: [],
@@ -17,7 +17,7 @@ describe("getDirsFromArgs", () => {
   });
 
   test("parses --local followed by dirs", async () => {
-    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const { getDirsFromArgs } = await import("./evaluate-args");
     const result = await getDirsFromArgs(["--local", "/tmp", "./src"]);
     expect(result).toEqual({
       localDirs: ["/tmp", "./src"],
@@ -26,7 +26,7 @@ describe("getDirsFromArgs", () => {
   });
 
   test("parses --remote followed by dirs", async () => {
-    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const { getDirsFromArgs } = await import("./evaluate-args");
     const result = await getDirsFromArgs(["--remote", "/uploads", "public"]);
     expect(result).toEqual({
       localDirs: [],
@@ -35,7 +35,7 @@ describe("getDirsFromArgs", () => {
   });
 
   test("switches to remote after --remote", async () => {
-    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const { getDirsFromArgs } = await import("./evaluate-args");
     const result = await getDirsFromArgs([
       "--local",
       "/tmp",
@@ -50,7 +50,7 @@ describe("getDirsFromArgs", () => {
   });
 
   test("switches back to local after --local", async () => {
-    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const { getDirsFromArgs } = await import("./evaluate-args");
     const result = await getDirsFromArgs([
       "--remote",
       "/cloud",
@@ -65,7 +65,7 @@ describe("getDirsFromArgs", () => {
   });
 
   test("ignores args before any flag", async () => {
-    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const { getDirsFromArgs } = await import("./evaluate-args");
     const result = await getDirsFromArgs([
       "bun",
       "run",
@@ -80,7 +80,7 @@ describe("getDirsFromArgs", () => {
   });
 
   test("both local and remote with multiple switches", async () => {
-    const { getDirsFromArgs } = await import("./get-dirs-from-args");
+    const { getDirsFromArgs } = await import("./evaluate-args");
     const result = await getDirsFromArgs([
       "--local",
       "a",
@@ -94,5 +94,44 @@ describe("getDirsFromArgs", () => {
       localDirs: ["a", "b", "c"],
       remoteDirs: ["x"],
     });
+  });
+});
+
+describe("getPromptFromArgs", () => {
+  test("returns null when no --prompt arg is present", async () => {
+    const { getPromptFromArgs } = await import("./evaluate-args");
+    const result = await getPromptFromArgs(["bun", "run", "host.ts"]);
+    expect(result).toBeNull();
+  });
+
+  test("returns the string following --prompt", async () => {
+    const { getPromptFromArgs } = await import("./evaluate-args");
+    const result = await getPromptFromArgs([
+      "bun",
+      "run",
+      "host.ts",
+      "--prompt",
+      "hello world",
+    ]);
+    expect(result).toBe("hello world");
+  });
+
+  test("works regardless of arg order", async () => {
+    const { getPromptFromArgs } = await import("./evaluate-args");
+    const result = await getPromptFromArgs([
+      "--local",
+      "foo/",
+      "--prompt",
+      "upload files",
+      "--remote",
+      "/",
+    ]);
+    expect(result).toBe("upload files");
+  });
+
+  test("returns null when --prompt has no following value", async () => {
+    const { getPromptFromArgs } = await import("./evaluate-args");
+    const result = await getPromptFromArgs(["bun", "run", "host.ts", "--prompt"]);
+    expect(result).toBeNull();
   });
 });

--- a/lib/get-mcp-config.test.ts
+++ b/lib/get-mcp-config.test.ts
@@ -9,7 +9,6 @@ describe("getConfig", () => {
       expect(config).toHaveProperty("mcpServers");
       expect(config).toHaveProperty("providers");
       expect(config).toHaveProperty("agentProvider");
-      expect(config).toHaveProperty("isChatEnabled");
       expect(typeof config.mcpServers).toBe("object");
       expect(typeof config.providers).toBe("object");
       const activeProvider = config.providers[config.agentProvider];

--- a/lib/host-agent.test.ts
+++ b/lib/host-agent.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, mock, test } from "bun:test";
 import { connectAgentServer, initAgent } from "./host-agent";
 import type { McpConfig } from "../config-validation";
-import type { AllowedDirs } from "./get-dirs-from-args";
+import type { AllowedDirs } from "./evaluate-args";
 
 const connectRemoteMock = mock(async (_dirs: AllowedDirs) => ({
   tools: [],
-  disconnect: mock(async () => {}),
+  disconnect: mock(async () => { }),
   toolMap: new Map(),
 }));
 
 const connectLocalMock = mock(async (_dirs: AllowedDirs) => ({
   tools: [],
-  disconnect: mock(async () => {}),
+  disconnect: mock(async () => { }),
   toolMap: new Map(),
 }));
 

--- a/lib/host-agent.ts
+++ b/lib/host-agent.ts
@@ -2,7 +2,7 @@ import { LocalAgent } from "../agents/local-agent";
 import { RemoteAgent } from "../agents/remote-agent";
 import type { McpConfig, ProviderOption } from "../config-validation";
 import { HOST_INSTRUCTIONS } from "../host-instructions";
-import type { AllowedDirs } from "./get-dirs-from-args";
+import type { AllowedDirs } from "./evaluate-args";
 
 export type UplinkAgent = RemoteAgent | LocalAgent;
 

--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -23,6 +23,5 @@
       "models": ["openai/gpt-oss-20b"]
     }
   },
-  "agentProvider": "remoteAgent",
-  "isChatEnabled": true
+  "agentProvider": "remoteAgent"
 }


### PR DESCRIPTION
#### Summary

- Introduces a --prompt CLI flag that lets you run the host in oneshot mode: answer a single prompt and exit.
- Keeps --local / --remote strictly for configuring allowed directories, without changing chat vs oneshot behavior.
- Updates docs and tests to describe and lock in the new oneshot flow.